### PR TITLE
Hashmap get unchecked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ __internal-fuzz = ["libz-ng-sys"]
 
 [dependencies]
 libc = "0.2.151"
-libz-ng-sys = { version = "1.1.12", optional = true }
+libz-ng-sys = { version = "1.1.15", optional = true }
 
 [dev-dependencies]
 libloading = "0.8.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ features = ["arbitrary-derive"]
 
 [dependencies]
 libc = "0.2.151"
-libz-ng-sys = "1.1.12"
+libz-ng-sys = "1.1.15"
 libloading = "0.8.1"
 
 [dependencies.zlib]

--- a/src/deflate/hash_calc.rs
+++ b/src/deflate/hash_calc.rs
@@ -1,5 +1,60 @@
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
+pub struct ZlibHashMap<'a> {
+    pub prev: &'a mut [u16],
+    pub head: &'a mut [u16; HASH_SIZE],
+
+    // equal to the window_mask if prev.len() == window_size
+    pub prev_mask: usize,
+}
+
+impl<'a> ZlibHashMap<'a> {
+    pub fn new(prev: &'a mut [u16], head: &'a mut [u16; HASH_SIZE]) -> Self {
+        assert!(prev.len().is_power_of_two());
+
+        Self {
+            prev_mask: prev.len() - 1,
+            prev,
+            head,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.head.fill(0)
+    }
+
+    #[inline(always)]
+    pub fn insert(&mut self, hash: u16, position: u16) -> u16 {
+        let head = self.head[hash as usize];
+
+        if head != position {
+            let index = position as usize & self.prev_mask;
+            // safety: the mask ensures the index is in bounds
+            unsafe { *self.prev.get_unchecked_mut(index) = head };
+
+            // safety: `hash` is a u16, and all u16 values are in bounds
+            const _: () = assert!(HASH_SIZE >= u16::MAX as usize);
+            unsafe { *self.head.get_unchecked_mut(hash as usize) = position };
+        }
+
+        head
+    }
+
+    #[inline(always)]
+    pub fn get_prev(&self, position: u16) -> u16 {
+        let index = position as usize & self.prev_mask;
+        // safety: the mask ensures the index is in bounds
+        unsafe { *self.prev.get_unchecked(index) }
+    }
+
+    #[inline(always)]
+    pub fn get_head(&self, hash: u16) -> u16 {
+        // safety: `hash` is a u16, and all u16 values are in bounds
+        const _: () = assert!(HASH_SIZE >= u16::MAX as usize);
+        unsafe { *self.head.get_unchecked(hash as usize) }
+    }
+}
+
 pub trait HashCalc {
     const HASH_CALC_OFFSET: usize;
     const HASH_CALC_MASK: u32;
@@ -20,15 +75,7 @@ pub trait HashCalc {
         h = Self::hash_calc(h, val);
         h &= Self::HASH_CALC_MASK;
 
-        let hm = h as usize;
-
-        let head = state.head[hm];
-        if head != string as u16 {
-            state.prev[string & state.w_mask] = head;
-            state.head[hm] = string as u16;
-        }
-
-        head
+        state.hash_map.insert(h as u16, string as u16)
     }
 
     fn insert_string(state: &mut State, string: usize, count: usize) {
@@ -47,14 +94,7 @@ pub trait HashCalc {
             h = Self::hash_calc(h, val);
             h &= Self::HASH_CALC_MASK;
 
-            // hm = HASH_CALC_VAR;
-            let hm = h as usize;
-
-            let head = state.head[hm];
-            if head != idx {
-                state.prev[idx as usize & state.w_mask] = head;
-                state.head[hm] = idx;
-            }
+            state.hash_map.insert(h as u16, idx);
         }
     }
 }
@@ -74,6 +114,25 @@ impl HashCalc for StandardHashCalc {
 
 pub struct RollHashCalc;
 
+impl RollHashCalc {
+    // so that we can test the actual implementation
+    #[inline(always)]
+    fn quick_insert_string_help(
+        window: &[u8],
+        string: usize,
+        hash_map: &mut ZlibHashMap,
+        ins_h: &mut usize,
+    ) -> u16 {
+        let slice = &window[string + Self::HASH_CALC_OFFSET..];
+
+        let val = slice[0] as u32;
+        *ins_h = Self::hash_calc(*ins_h as u32, val) as usize;
+        *ins_h &= Self::HASH_CALC_MASK as usize;
+
+        hash_map.insert(*ins_h as u16, string as u16)
+    }
+}
+
 impl HashCalc for RollHashCalc {
     const HASH_CALC_OFFSET: usize = STD_MIN_MATCH - 1;
 
@@ -85,21 +144,12 @@ impl HashCalc for RollHashCalc {
     }
 
     fn quick_insert_string(state: &mut State, string: usize) -> u16 {
-        let slice = &state.window.filled()[string + Self::HASH_CALC_OFFSET..];
-
-        let val = slice[0] as u32;
-        state.ins_h = Self::hash_calc(state.ins_h as u32, val) as usize;
-        state.ins_h &= Self::HASH_CALC_MASK as usize;
-
-        let hm = state.ins_h;
-
-        let head = state.head[hm];
-        if head != string as u16 {
-            state.prev[string & state.w_mask] = head;
-            state.head[hm] = string as u16;
-        }
-
-        head
+        Self::quick_insert_string_help(
+            state.window.filled(),
+            string,
+            &mut state.hash_map,
+            &mut state.ins_h,
+        )
     }
 
     fn insert_string(state: &mut State, string: usize, count: usize) {
@@ -110,13 +160,8 @@ impl HashCalc for RollHashCalc {
 
             state.ins_h = Self::hash_calc(state.ins_h as u32, val as u32) as usize;
             state.ins_h &= Self::HASH_CALC_MASK as usize;
-            let hm = state.ins_h;
 
-            let head = state.head[hm];
-            if head != idx {
-                state.prev[idx as usize & state.w_mask] = head;
-                state.head[hm] = idx;
-            }
+            state.hash_map.insert(state.ins_h as u16, idx);
         }
     }
 }
@@ -133,18 +178,51 @@ impl HashCalc for Crc32HashCalc {
     }
 }
 
-#[test]
-fn roll_hash_calc() {
-    assert_eq!(RollHashCalc::hash_calc(2565, 93), 82173);
-    assert_eq!(RollHashCalc::hash_calc(16637, 10), 532394);
-    assert_eq!(RollHashCalc::hash_calc(8106, 100), 259364);
-    assert_eq!(RollHashCalc::hash_calc(29988, 101), 959717);
-    assert_eq!(RollHashCalc::hash_calc(9445, 98), 302274);
-    assert_eq!(RollHashCalc::hash_calc(7362, 117), 235573);
-    assert_eq!(RollHashCalc::hash_calc(6197, 103), 198343);
-    assert_eq!(RollHashCalc::hash_calc(1735, 32), 55488);
-    assert_eq!(RollHashCalc::hash_calc(22720, 61), 727101);
-    assert_eq!(RollHashCalc::hash_calc(6205, 32), 198528);
-    assert_eq!(RollHashCalc::hash_calc(3826, 117), 122421);
-    assert_eq!(RollHashCalc::hash_calc(24117, 101), 771781);
+#[cfg(test)]
+mod test {
+    use crate::deflate::hash_calc::ZlibHashMap;
+
+    use super::{HashCalc, RollHashCalc};
+
+    #[test]
+    fn roll_hash_calc() {
+        assert_eq!(RollHashCalc::hash_calc(2565, 93), 82173);
+        assert_eq!(RollHashCalc::hash_calc(16637, 10), 532394);
+        assert_eq!(RollHashCalc::hash_calc(8106, 100), 259364);
+        assert_eq!(RollHashCalc::hash_calc(29988, 101), 959717);
+        assert_eq!(RollHashCalc::hash_calc(9445, 98), 302274);
+        assert_eq!(RollHashCalc::hash_calc(7362, 117), 235573);
+        assert_eq!(RollHashCalc::hash_calc(6197, 103), 198343);
+        assert_eq!(RollHashCalc::hash_calc(1735, 32), 55488);
+        assert_eq!(RollHashCalc::hash_calc(22720, 61), 727101);
+        assert_eq!(RollHashCalc::hash_calc(6205, 32), 198528);
+        assert_eq!(RollHashCalc::hash_calc(3826, 117), 122421);
+        assert_eq!(RollHashCalc::hash_calc(24117, 101), 771781);
+    }
+
+    #[test]
+    fn construct_prev() {
+        let window = "aaaabaaacaaa";
+        //             ^   ^   ^
+        //             1   5   9
+
+        let mut ins_h = 3137;
+
+        let mut prev = [0; 1 << 8];
+        let mut head = [0; 1 << 16];
+
+        let mut hash_map = ZlibHashMap::new(&mut prev, &mut head);
+
+        for (i, _) in window.as_bytes().iter().take(window.len() - 2).enumerate() {
+            RollHashCalc::quick_insert_string_help(window.as_bytes(), i, &mut hash_map, &mut ins_h);
+        }
+
+        assert_eq!(&prev[..10], &[0, 0, 0, 0, 0, 1, 0, 0, 0, 5]);
+
+        // the hash (ins_h) points to the start of the chain, then the rest of the chain is stored
+        // in `prev`.
+        assert_eq!(head[ins_h], 9);
+        assert_eq!(prev[9], 5);
+        assert_eq!(prev[5], 1);
+    }
 }

--- a/src/deflate/longest_match.rs
+++ b/src/deflate/longest_match.rs
@@ -42,7 +42,7 @@ fn longest_match_help<const SLOW: bool>(
         () => {
             chain_length -= 1;
             if chain_length > 0 {
-                cur_match = state.prev[cur_match as usize & wmask];
+                cur_match = state.hash_map.get_prev(cur_match);
 
                 if cur_match > limit {
                     continue;
@@ -116,7 +116,7 @@ fn longest_match_help<const SLOW: bool>(
                 hash = (state.update_hash)(hash, *b as u32);
 
                 /* If we're starting with best_len >= 3, we can use offset search. */
-                pos = state.head[hash as usize];
+                pos = state.hash_map.get_head(hash as u16);
                 if pos < cur_match {
                     match_offset = (i - 2) as Pos;
                     cur_match = pos;
@@ -251,7 +251,7 @@ fn longest_match_help<const SLOW: bool>(
                 let mut next_pos = cur_match;
 
                 for i in 0..=len - STD_MIN_MATCH {
-                    pos = state.prev[(cur_match as usize + i) & wmask];
+                    pos = state.hash_map.get_prev(cur_match + i as Pos);
                     if pos < next_pos {
                         /* Hash chain is more distant, use it */
                         if pos <= limit_base + i as Pos {
@@ -276,7 +276,8 @@ fn longest_match_help<const SLOW: bool>(
                 hash = (state.update_hash)(hash, scan_endstr[1] as u32);
                 hash = (state.update_hash)(hash, scan_endstr[2] as u32);
 
-                pos = state.head[hash as usize];
+                pos = state.hash_map.get_head(hash as u16);
+
                 if pos < cur_match {
                     match_offset = (len - (STD_MIN_MATCH + 1)) as Pos;
                     if pos <= limit_base + match_offset {

--- a/src/deflate/longest_match.rs
+++ b/src/deflate/longest_match.rs
@@ -25,7 +25,6 @@ fn longest_match_help<const SLOW: bool>(
     let mut match_start = state.match_start;
 
     let strstart = state.strstart;
-    let wmask = state.w_mask;
     let window = state.window.filled();
     let scan = &window[strstart..];
     let mut limit: Pos;

--- a/src/deflate/slide_hash.rs
+++ b/src/deflate/slide_hash.rs
@@ -15,8 +15,8 @@ mod rust {
     pub fn slide_hash(state: &mut State) {
         let wsize = state.w_size as u16;
 
-        slide_hash_chain(state.head, wsize);
-        slide_hash_chain(state.prev, wsize);
+        slide_hash_chain(state.hash_map.head, wsize);
+        slide_hash_chain(state.hash_map.prev, wsize);
     }
 
     fn slide_hash_chain(table: &mut [u16], wsize: u16) {
@@ -38,8 +38,8 @@ mod avx2 {
         let wsize = state.w_size as u16;
         let ymm_wsize = unsafe { _mm256_set1_epi16(wsize as i16) };
 
-        slide_hash_chain(state.head, ymm_wsize);
-        slide_hash_chain(state.prev, ymm_wsize);
+        slide_hash_chain(state.hash_map.head, ymm_wsize);
+        slide_hash_chain(state.hash_map.prev, ymm_wsize);
     }
 
     fn slide_hash_chain(table: &mut [u16], wsize: __m256i) {


### PR DESCRIPTION
This

- combines the hashmap fields into their own struct (clearer, and useful for testing)
- uses unchecked access into the hashmap (the index is a u16, and the length of the array is `usize::MAX` or larger)

This marginally improves performance for compression level 9, uses fewer instructions, but uses more unsafe. We'll need a better benchmarking setup to confidently say that this tradeoff is worth it.