### PR TITLE
Hash direct calls

### DIFF
--- a/zlib-rs/src/deflate/algorithm/fast.rs
+++ b/zlib-rs/src/deflate/algorithm/fast.rs
@@ -33,7 +33,7 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
         // dictionary, and set hash_head to the head of the hash chain:
 
         if state.lookahead >= WANT_MIN_MATCH {
-            let hash_head = (state.quick_insert_string)(state, state.strstart);
+            let hash_head = state.quick_insert_string(state.strstart);
             dist = state.strstart as isize - hash_head as isize;
 
             /* Find the longest match, discarding those <= prev_length.
@@ -66,11 +66,11 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
                 match_len -= 1; /* string at strstart already in table */
                 state.strstart += 1;
 
-                (state.insert_string)(state, state.strstart, match_len);
+                state.insert_string(state.strstart, match_len);
                 state.strstart += match_len;
             } else {
                 state.strstart += match_len;
-                (state.quick_insert_string)(state, state.strstart + 2 - STD_MIN_MATCH);
+                state.quick_insert_string(state.strstart + 2 - STD_MIN_MATCH);
 
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -60,7 +60,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
         } else {
             hash_head = 0;
             if state.lookahead >= WANT_MIN_MATCH {
-                hash_head = (state.quick_insert_string)(state, state.strstart);
+                hash_head = state.quick_insert_string(state.strstart);
             }
 
             current_match.strstart = state.strstart as u16;
@@ -104,7 +104,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
                 < (state.window_size - MIN_LOOKAHEAD)
         {
             state.strstart = (current_match.strstart + current_match.match_length) as usize;
-            hash_head = (state.quick_insert_string)(state, state.strstart);
+            hash_head = state.quick_insert_string(state.strstart);
 
             next_match.strstart = state.strstart as u16;
             next_match.orgstart = next_match.strstart;
@@ -222,13 +222,9 @@ fn insert_match(state: &mut State, mut m: Match) {
         m.match_length -= 1;
         if m.match_length > 0 && m.strstart >= m.orgstart {
             if m.strstart + m.match_length > m.orgstart {
-                (state.insert_string)(state, m.strstart as usize, m.match_length as usize);
+                state.insert_string(m.strstart as usize, m.match_length as usize);
             } else {
-                (state.insert_string)(
-                    state,
-                    m.strstart as usize,
-                    (m.orgstart - m.strstart + 1) as usize,
-                );
+                state.insert_string(m.strstart as usize, (m.orgstart - m.strstart + 1) as usize);
             }
             m.strstart += m.match_length;
             m.match_length = 0;
@@ -247,17 +243,12 @@ fn insert_match(state: &mut State, mut m: Match) {
 
         if m.strstart >= m.orgstart {
             if m.strstart + m.match_length > m.orgstart {
-                (state.insert_string)(state, m.strstart as usize, m.match_length as usize);
+                state.insert_string(m.strstart as usize, m.match_length as usize);
             } else {
-                (state.insert_string)(
-                    state,
-                    m.strstart as usize,
-                    (m.orgstart - m.strstart + 1) as usize,
-                );
+                state.insert_string(m.strstart as usize, (m.orgstart - m.strstart + 1) as usize);
             }
         } else if m.orgstart < m.strstart + m.match_length {
-            (state.insert_string)(
-                state,
+            state.insert_string(
                 m.orgstart as usize,
                 (m.strstart + m.match_length - m.orgstart) as usize,
             );
@@ -269,7 +260,7 @@ fn insert_match(state: &mut State, mut m: Match) {
         m.match_length = 0;
 
         if (m.strstart as usize) >= (STD_MIN_MATCH - 2) {
-            (state.quick_insert_string)(state, m.strstart as usize + 2 - STD_MIN_MATCH);
+            state.quick_insert_string(m.strstart as usize + 2 - STD_MIN_MATCH);
         }
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not

--- a/zlib-rs/src/deflate/algorithm/quick.rs
+++ b/zlib-rs/src/deflate/algorithm/quick.rs
@@ -93,7 +93,7 @@ pub fn deflate_quick(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSt
         }
 
         if state.lookahead >= WANT_MIN_MATCH {
-            let hash_head = (state.quick_insert_string)(state, state.strstart);
+            let hash_head = state.quick_insert_string(state.strstart);
             let dist = state.strstart as isize - hash_head as isize;
 
             if dist <= state.max_dist() as isize && dist > 0 {

--- a/zlib-rs/src/deflate/algorithm/slow.rs
+++ b/zlib-rs/src/deflate/algorithm/slow.rs
@@ -43,7 +43,7 @@ pub fn deflate_slow(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
          * dictionary, and set hash_head to the head of the hash chain:
          */
         hash_head = if state.lookahead >= WANT_MIN_MATCH {
-            (state.quick_insert_string)(state, state.strstart)
+            state.quick_insert_string(state.strstart)
         } else {
             0
         };
@@ -98,7 +98,7 @@ pub fn deflate_slow(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
             let mov_fwd = state.prev_length - 1;
             if max_insert > state.strstart {
                 let insert_cnt = Ord::min(mov_fwd, max_insert - state.strstart);
-                (state.insert_string)(state, state.strstart + 1, insert_cnt);
+                state.insert_string(state.strstart + 1, insert_cnt);
             }
             state.prev_length = 0;
             state.match_available = false;

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -1,5 +1,12 @@
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
+#[derive(Debug, Clone, Copy)]
+pub enum HashCalcVariant {
+    Standard,
+    Crc32,
+    Roll,
+}
+
 pub trait HashCalc {
     const HASH_CALC_OFFSET: usize;
     const HASH_CALC_MASK: u32;

--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -103,11 +103,11 @@ fn longest_match_help<const SLOW: bool>(
             };
 
             let mut hash = 0;
-            hash = (state.update_hash)(hash, *scan1 as u32);
-            hash = (state.update_hash)(hash, *scan2 as u32);
+            hash = state.update_hash(hash, *scan1 as u32);
+            hash = state.update_hash(hash, *scan2 as u32);
 
             for (i, b) in scanrest.iter().enumerate() {
-                hash = (state.update_hash)(hash, *b as u32);
+                hash = state.update_hash(hash, *b as u32);
 
                 /* If we're starting with best_len >= 3, we can use offset search. */
                 pos = state.head[hash as usize];
@@ -280,9 +280,9 @@ fn longest_match_help<const SLOW: bool>(
                 };
 
                 let mut hash = 0;
-                hash = (state.update_hash)(hash, scan0 as u32);
-                hash = (state.update_hash)(hash, scan1 as u32);
-                hash = (state.update_hash)(hash, scan2 as u32);
+                hash = state.update_hash(hash, scan0 as u32);
+                hash = state.update_hash(hash, scan1 as u32);
+                hash = state.update_hash(hash, scan2 as u32);
 
                 pos = state.head[hash as usize];
                 if pos < cur_match {


### PR DESCRIPTION
reduces the number of instructions some, and seems beneficial for performance too (but it's hard to tell).