### PR TITLE
Add the metadata needed by cargo-c

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -325,7 +325,7 @@ jobs:
           targets: ${{matrix.target}}
       - name: Install cargo-c
         env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/tag/v0.10.5/download
+          LINK: https://github.com/lu-zero/cargo-c/releases/download/v0.10.5
         run: |
           curl -L "$LINK/cargo-c-x86_64-unknown-linux-musl.tar.gz" |
           tar xz -C $HOME/.cargo/bin

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -325,7 +325,7 @@ jobs:
           targets: ${{matrix.target}}
       - name: Install cargo-c
         env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+          LINK: https://github.com/lu-zero/cargo-c/releases/tag/v0.10.5/download
         run: |
           curl -L "$LINK/cargo-c-x86_64-unknown-linux-musl.tar.gz" |
           tar xz -C $HOME/.cargo/bin

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -251,7 +251,7 @@ jobs:
           done
 
   link-c-dynamic-library:
-    name: dynamic library
+    name: vanilla dynamic library
     strategy:
       matrix:
         include:
@@ -303,6 +303,45 @@ jobs:
         run: |
           cargo build --release --target ${{matrix.target}} --features=custom-prefix
           objdump -tT target/${{matrix.target}}/release/deps/libz_rs.so | grep -q "MY_CUSTOM_PREFIX_uncompress" || (echo "symbol not found!" && exit 1)
+
+  cargo-c-dynamic-library:
+    name: cargo-c dynamic library
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+        features:
+          - ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+        with:
+          toolchain: stable
+          targets: ${{matrix.target}}
+      - name: Install cargo-c
+        env:
+          LINK: https://github.com/lu-zero/cargo-c/releases/latest/download
+        run: |
+          curl -L "$LINK/cargo-c-x86_64-unknown-linux-musl.tar.gz" |
+          tar xz -C $HOME/.cargo/bin
+      - name: build with and test the result of cargo-c
+        working-directory: libz-rs-sys-cdylib
+        run: |
+          # build using cargo-c this time
+          cargo cinstall --offline --release --destdir=/tmp/cargo-cbuild-libz-rs
+          tree /tmp/cargo-cbuild-libz-rs
+          # verify that the SONAME  is set and includes a version
+          objdump -p target/x86_64-unknown-linux-gnu/release/libz_rs.so | awk '/SONAME/{print $2}' | grep -E 'libz_rs\.so\.[0-9]+\.[0-9]+'
+          # build zpipe with our library
+          cc -o zpipe zpipe.c -L/tmp/cargo-cbuild-libz-rs/usr/local/lib/x86_64-linux-gnu -lz_rs
+          export LD_LIBRARY_PATH=/tmp/cargo-cbuild-libz-rs/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+          ./zpipe < Cargo.toml | ./zpipe -d > out.txt
+          cmp -s Cargo.toml out.txt
 
   wasm32:
     name: "wasm32"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -336,7 +336,7 @@ jobs:
           cargo cinstall --offline --release --destdir=/tmp/cargo-cbuild-libz-rs
           tree /tmp/cargo-cbuild-libz-rs
           # verify that the SONAME  is set and includes a version
-          objdump -p target/x86_64-unknown-linux-gnu/release/libz_rs.so | awk '/SONAME/{print $2}' | grep -E 'libz_rs\.so\.[0-9]+\.[0-9]+'
+          objdump -p target/x86_64-unknown-linux-gnu/release/libz_rs.so | awk '/SONAME/{print $2}' | grep -E 'libz_rs\.so\.1'
           # build zpipe with our library
           cc -o zpipe zpipe.c -L/tmp/cargo-cbuild-libz-rs/usr/local/lib/x86_64-linux-gnu -lz_rs
           export LD_LIBRARY_PATH=/tmp/cargo-cbuild-libz-rs/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH

--- a/libz-rs-sys-cdylib/Cargo.toml
+++ b/libz-rs-sys-cdylib/Cargo.toml
@@ -19,6 +19,17 @@ default = ["c-allocator"] # when used as a cdylib crate, use the c allocator
 c-allocator = ["libz-rs-sys/c-allocator"] # by default, use malloc/free for memory allocation
 rust-allocator = ["libz-rs-sys/rust-allocator", "libz-rs-sys/std"] # by default, use the rust global alloctor for memory allocation
 custom-prefix = ["libz-rs-sys/custom-prefix"] # use the LIBZ_RS_SYS_PREFIX to prefix all exported symbols
+capi = []
 
 [dependencies]
 libz-rs-sys = { version = "0.4.0", path = "../libz-rs-sys", default-features = false }
+
+[package.metadata.capi.library]
+name = "z_rs"
+
+[package.metadata.capi.header]
+enabled = false
+
+[package.metadata.capi.pkg_config]
+name = "libz_rs"
+filename = "libz_rs"

--- a/libz-rs-sys-cdylib/Cargo.toml
+++ b/libz-rs-sys-cdylib/Cargo.toml
@@ -25,6 +25,7 @@ capi = []
 libz-rs-sys = { version = "0.4.0", path = "../libz-rs-sys", default-features = false }
 
 [package.metadata.capi.library]
+version = "1.3.0" # the zlib api version we match
 name = "z_rs"
 
 [package.metadata.capi.header]

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -17,6 +17,17 @@ rust-allocator = ["zlib-rs/rust-allocator"] # by default, use the rust global al
 std = ["zlib-rs/std"] # assume `::std` is available
 custom-prefix = [] # use the LIBZ_RS_SYS_PREFIX to prefix all exported symbols
 testing-prefix = [] # prefix all symbols with LIBZ_RS_SYS_TEST_ for testing
+capi = []
 
 [dependencies]
 zlib-rs = { workspace = true, default-features = false }
+
+[package.metadata.capi.library]
+name = "z_rs"
+
+[package.metadata.capi.header]
+enabled = false
+
+[package.metadata.capi.pkg_config]
+name = "libz_rs"
+filename = "libz_rs"

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -17,17 +17,6 @@ rust-allocator = ["zlib-rs/rust-allocator"] # by default, use the rust global al
 std = ["zlib-rs/std"] # assume `::std` is available
 custom-prefix = [] # use the LIBZ_RS_SYS_PREFIX to prefix all exported symbols
 testing-prefix = [] # prefix all symbols with LIBZ_RS_SYS_TEST_ for testing
-capi = []
 
 [dependencies]
 zlib-rs = { workspace = true, default-features = false }
-
-[package.metadata.capi.library]
-name = "z_rs"
-
-[package.metadata.capi.header]
-enabled = false
-
-[package.metadata.capi.pkg_config]
-name = "libz_rs"
-filename = "libz_rs"


### PR DESCRIPTION
Fixes #174 

It does not install any header, uses `libz_rs` as name in pkg-config and `z_rs` as library name.

The default cargo `cinstall --destdir=/some/place`  would produce this on macos:

``` tree
└── usr
    └── local
        └── lib
            ├── libz_rs.0.2.1.dylib
            ├── libz_rs.0.2.dylib -> libz_rs.0.2.1.dylib
            ├── libz_rs.a
            ├── libz_rs.dylib -> libz_rs.0.2.1.dylib
            └── pkgconfig
                └── libz_rs.pc
```