### PR TITLE
fix for reading/writing uninitialized memory

### DIFF
--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -1450,6 +1450,9 @@ fn version_error() {
     };
     assert_eq!(ret, Z_OK);
 
+    let ret = unsafe { inflateEnd(stream.as_mut_ptr()) };
+    assert_eq!(ret, Z_OK);
+
     // invalid stream size
     let ret = unsafe { inflateInit_(stream.as_mut_ptr(), zlibVersion(), 1) };
     assert_eq!(ret, Z_VERSION_ERROR);

--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -638,7 +638,6 @@ fn try_inflate(input: &[u8], err: c_int) -> c_int {
     /* allocate work areas */
     let size = len << 3;
     let mut out = vec![0; size];
-    dbg!(out.as_slice().as_ptr_range());
     // let mut win = vec![0; 32768];
 
     //    /* first with inflate */
@@ -1655,6 +1654,7 @@ fn prng_bytes(seed: u64, bytes: &mut [u8], step: usize) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "slow")]
 fn test_inflate_flush_block() {
     let window_bits = -15; // Raw
     const CHUNK: usize = 16384;

--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -48,6 +48,11 @@ impl<'a> BitReader<'a> {
     }
 
     #[inline(always)]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr as *mut u8
+    }
+
+    #[inline(always)]
     pub fn as_slice(&self) -> &[u8] {
         let len = self.bytes_remaining();
         unsafe { core::slice::from_raw_parts(self.ptr, len) }

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -107,6 +107,7 @@ impl<'a> Writer<'a> {
         range: Range<usize>,
     ) {
         let len = range.end - range.start;
+
         if self.remaining() >= core::mem::size_of::<C>() {
             // Safety: we know that our window has at least a core::mem::size_of::<C>() extra bytes
             // at the end, making it always safe to perform an (unaligned) Chunk read anywhere in

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -108,7 +108,7 @@ impl<'a> Writer<'a> {
     ) {
         let len = range.end - range.start;
 
-        if self.remaining() >= core::mem::size_of::<C>() {
+        if self.remaining() >= len + core::mem::size_of::<C>() {
             // Safety: we know that our window has at least a core::mem::size_of::<C>() extra bytes
             // at the end, making it always safe to perform an (unaligned) Chunk read anywhere in
             // the window slice.


### PR DESCRIPTION
The issues were in unreleased code, so there is not much of a risk here. Glad we caught it though.

I've also fixed the rest of the `test-libz-rs-sys` tests so that they can run under miri. I'll add some CI infra for that in a followup (probably requires some fighting with github CI).

cc @inahga