### PR TITLE
fix bug in inflate_fast when refilling

### DIFF
--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -116,26 +116,6 @@ impl<'a> BitReader<'a> {
     }
 
     #[inline(always)]
-    pub fn refill_and<T>(&mut self, f: impl Fn(u64) -> T) -> T {
-        debug_assert!(self.bytes_remaining() >= 8);
-
-        // the trick of this function is that the read can happen concurrently
-        // with the arithmetic below. That makes the read effectively free.
-        let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) }.to_le();
-        let next_bit_buffer = self.bit_buffer | read << self.bits_used;
-
-        let increment = (63 - self.bits_used) >> 3;
-        self.ptr = self.ptr.wrapping_add(increment as usize);
-        self.bits_used |= 56;
-
-        let result = f(self.bit_buffer);
-
-        self.bit_buffer = next_bit_buffer;
-
-        result
-    }
-
-    #[inline(always)]
     pub fn bits(&mut self, n: usize) -> u64 {
         // debug_assert!( n <= self.bits_used, "{n} bits requested, but only {} avaliable", self.bits_used);
 


### PR DESCRIPTION
fix #213

the logic assumed a certain number of bits would be available; this was false in general.