### PR TITLE
fix panic in the stored algorithm

### DIFF
--- a/zlib-rs/src/adler32/avx2.rs
+++ b/zlib-rs/src/adler32/avx2.rs
@@ -135,6 +135,8 @@ unsafe fn helper_32_bytes(mut adler0: u32, mut adler1: u32, src: &[__m256i]) -> 
 #[cfg(test)]
 #[cfg(target_feature = "avx2")]
 mod test {
+    use core::mem::MaybeUninit;
+
     use super::*;
 
     #[test]

--- a/zlib-rs/src/deflate/algorithm/stored.rs
+++ b/zlib-rs/src/deflate/algorithm/stored.rs
@@ -131,10 +131,14 @@ pub fn deflate_stored(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
                 /* Slide the window down. */
                 state.strstart -= state.w_size;
 
+                // make sure we don't copy uninitialized bytes. While we discard the first lower w_size
+                // bytes, it is not guaranteed that the upper w_size bytes are all initialized
+                let copy = Ord::min(state.strstart, state.window.filled().len() - state.w_size);
+
                 state
                     .window
                     .filled_mut()
-                    .copy_within(state.w_size..state.w_size + state.strstart, 0);
+                    .copy_within(state.w_size..state.w_size + copy, 0);
 
                 if state.matches < 2 {
                     state.matches += 1; /* add a pending slide_hash() */


### PR DESCRIPTION
fixes https://github.com/trifectatechfoundation/zlib-rs/issues/218

the logic attempted to copy uninitialized bytes. A panic prevented this from happening, and this commit fixes that panic by only copying the initialized section.

In the future we might, in rust, be able to just come up with a better mechanism around the uninitialized bytes in that window. For now this works fine, I don't think the performance is relevant here.

cc @inahga 