### PR TITLE
optimize the `medium` algorithm

### DIFF
--- a/fuzz/fuzz_targets/checksum.rs
+++ b/fuzz/fuzz_targets/checksum.rs
@@ -21,23 +21,6 @@ fuzz_target!(|input: (Vec<u8>, u32)| {
     }
 
     {
-        let expected = {
-            let mut h = crc32fast::Hasher::new_with_initial(0);
-            h.update(&input[..]);
-            h.finalize()
-        };
-
-        let mut buf = [0; 1 << 16];
-        let mut dst = zlib_rs::read_buf::ReadBuf::new(&mut buf[..input.len()]);
-
-        let actual = zlib_rs::crc32::crc32_copy(&mut dst, input.as_slice());
-
-        assert_eq!(expected, actual);
-
-        assert_eq!(input, dst.filled());
-    }
-
-    {
         use zlib_rs::{crc32, crc32_combine};
 
         let data = &input;

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1373,9 +1373,7 @@ impl<'a> State<'a> {
         l_desc: &mut TreeDesc<HEAP_SIZE>,
         unmatched: u8,
     ) -> bool {
-        sym_buf.push(0);
-        sym_buf.push(0);
-        sym_buf.push(unmatched);
+        sym_buf.push_lit(unmatched);
 
         *l_desc.dyn_tree[unmatched as usize].freq_mut() += 1;
 
@@ -1395,8 +1393,7 @@ impl<'a> State<'a> {
 
     #[inline(always)]
     pub(crate) fn tally_dist(&mut self, mut dist: usize, len: usize) -> bool {
-        let symbols = [dist as u8, (dist >> 8) as u8, len as u8];
-        self.sym_buf.extend(&symbols);
+        self.sym_buf.push_dist(dist as u16, len as u8);
 
         self.matches += 1;
         dist -= 1;

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1335,6 +1335,7 @@ impl<'a> State<'a> {
         self.lit_bufsize * 4
     }
 
+    #[inline(always)]
     pub(crate) fn update_hash(&self, h: u32, val: u32) -> u32 {
         match self.hash_calc_variant {
             HashCalcVariant::Standard => StandardHashCalc::update_hash(h, val),
@@ -1343,6 +1344,7 @@ impl<'a> State<'a> {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn quick_insert_string(&mut self, string: usize) -> u16 {
         match self.hash_calc_variant {
             HashCalcVariant::Standard => StandardHashCalc::quick_insert_string(self, string),
@@ -1351,6 +1353,7 @@ impl<'a> State<'a> {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn insert_string(&mut self, string: usize, count: usize) {
         match self.hash_calc_variant {
             HashCalcVariant::Standard => StandardHashCalc::insert_string(self, string, count),
@@ -1359,6 +1362,7 @@ impl<'a> State<'a> {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn tally_lit(&mut self, unmatched: u8) -> bool {
         self.sym_buf.push(0);
         self.sym_buf.push(0);
@@ -1380,6 +1384,7 @@ impl<'a> State<'a> {
         self::trees_tbl::DIST_CODE[index]
     }
 
+    #[inline(always)]
     pub(crate) fn tally_dist(&mut self, mut dist: usize, len: usize) -> bool {
         let symbols = [dist as u8, (dist >> 8) as u8, len as u8];
         self.sym_buf.extend(&symbols);

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1364,11 +1364,20 @@ impl<'a> State<'a> {
 
     #[inline(always)]
     pub(crate) fn tally_lit(&mut self, unmatched: u8) -> bool {
-        self.sym_buf.push(0);
-        self.sym_buf.push(0);
-        self.sym_buf.push(unmatched);
+        Self::tally_lit_help(&mut self.sym_buf, &mut self.l_desc, unmatched)
+    }
 
-        *self.l_desc.dyn_tree[unmatched as usize].freq_mut() += 1;
+    #[inline(always)]
+    pub(crate) fn tally_lit_help(
+        sym_buf: &mut ReadBuf<'a>,
+        l_desc: &mut TreeDesc<HEAP_SIZE>,
+        unmatched: u8,
+    ) -> bool {
+        sym_buf.push(0);
+        sym_buf.push(0);
+        sym_buf.push(unmatched);
+
+        *l_desc.dyn_tree[unmatched as usize].freq_mut() += 1;
 
         assert!(
             unmatched as usize <= STD_MAX_MATCH - STD_MIN_MATCH,
@@ -1376,7 +1385,7 @@ impl<'a> State<'a> {
         );
 
         // signal that the current block should be flushed
-        self.sym_buf.len() == self.sym_buf.capacity() - 3
+        sym_buf.len() == sym_buf.capacity() - 3
     }
 
     const fn d_code(dist: usize) -> u8 {
@@ -1814,7 +1823,7 @@ impl StaticTreeDesc {
 }
 
 #[derive(Clone)]
-struct TreeDesc<const N: usize> {
+pub(crate) struct TreeDesc<const N: usize> {
     dyn_tree: [Value; N],
     max_code: usize,
     stat_desc: &'static StaticTreeDesc,

--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -184,29 +184,25 @@ struct Match {
     orgstart: u16,
 }
 
-fn emit_match(state: &mut State, mut m: Match) -> bool {
+fn emit_match(state: &mut State, m: Match) -> bool {
     let mut bflush = false;
 
     /* matches that are not long enough we need to emit as literals */
     if (m.match_length as usize) < WANT_MIN_MATCH {
-        while m.match_length > 0 {
-            let lc = state.window.filled()[state.strstart];
-            bflush |= state.tally_lit(lc);
+        for lc in &state.window.filled()[state.strstart..][..m.match_length as usize] {
+            bflush |= State::tally_lit_help(&mut state.sym_buf, &mut state.l_desc, *lc);
             state.lookahead -= 1;
-            m.strstart += 1;
-            m.match_length -= 1;
         }
-        return bflush;
+    } else {
+        // check_match(s, m.strstart, m.match_start, m.match_length);
+
+        bflush |= state.tally_dist(
+            (m.strstart - m.match_start) as usize,
+            m.match_length as usize - STD_MIN_MATCH,
+        );
+
+        state.lookahead -= m.match_length as usize;
     }
-
-    // check_match(s, m.strstart, m.match_start, m.match_length);
-
-    bflush |= state.tally_dist(
-        (m.strstart - m.match_start) as usize,
-        m.match_length as usize - STD_MIN_MATCH,
-    );
-
-    state.lookahead -= m.match_length as usize;
 
     bflush
 }

--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -211,6 +211,7 @@ fn emit_match(state: &mut State, mut m: Match) -> bool {
     bflush
 }
 
+#[inline(always)]
 fn insert_match(state: &mut State, mut m: Match) {
     if state.lookahead <= (m.match_length as usize + WANT_MIN_MATCH) {
         return;

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -43,12 +43,6 @@ impl<'a> ReadBuf<'a> {
         }
     }
 
-    /// Pointer to where the next byte will be written
-    #[inline]
-    pub fn next_out(&mut self) -> *mut MaybeUninit<u8> {
-        self.buf[self.filled..].as_mut_ptr()
-    }
-
     /// Pointer to the start of the `ReadBuf`
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
@@ -103,7 +97,7 @@ impl<'a> ReadBuf<'a> {
 
     /// Returns the number of bytes at the end of the slice that have not yet been filled.
     #[inline]
-    pub fn remaining(&self) -> usize {
+    fn remaining(&self) -> usize {
         self.capacity() - self.filled
     }
 
@@ -113,20 +107,6 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn clear(&mut self) {
         self.filled = 0;
-    }
-
-    /// Advances the size of the filled region of the buffer.
-    ///
-    /// The number of initialized bytes is not changed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the filled region of the buffer would become larger than the initialized region.
-    #[inline]
-    #[track_caller]
-    pub fn advance(&mut self, n: usize) {
-        let new = self.filled.checked_add(n).expect("filled overflow");
-        self.set_filled(new);
     }
 
     /// Sets the size of the filled region of the buffer.

--- a/zlib-rs/src/read_buf.rs
+++ b/zlib-rs/src/read_buf.rs
@@ -5,47 +5,15 @@ use core::mem::MaybeUninit;
 
 use crate::allocate::Allocator;
 
-/// A wrapper around a byte buffer that is incrementally filled and initialized.
-///
-/// This type is a sort of "double cursor". It tracks three regions in the
-/// buffer: a region at the beginning of the buffer that has been logically
-/// filled with data, a region that has been initialized at some point but not
-/// yet logically filled, and a region at the end that may be uninitialized.
-/// The filled region is guaranteed to be a subset of the initialized region.
-///
-/// In summary, the contents of the buffer can be visualized as:
-///
-/// ```not_rust
-/// [             capacity              ]
-/// [ filled |         unfilled         ]
-/// [    initialized    | uninitialized ]
-/// ```
-///
-/// It is undefined behavior to de-initialize any bytes from the uninitialized
-/// region, since it is merely unknown whether this region is uninitialized or
-/// not, and if part of it turns out to be initialized, it must stay initialized.
 pub struct ReadBuf<'a> {
-    buf: &'a mut [MaybeUninit<u8>],
+    buf: &'a mut [u8],
     filled: usize,
-    initialized: usize,
 }
 
 impl<'a> ReadBuf<'a> {
-    /// Creates a new `ReadBuf` from a fully initialized buffer.
-    #[inline]
-    pub fn new(buf: &'a mut [u8]) -> ReadBuf<'a> {
-        let initialized = buf.len();
-        let buf = unsafe { slice_to_uninit_mut(buf) };
-        ReadBuf {
-            buf,
-            filled: 0,
-            initialized,
-        }
-    }
-
     /// Pointer to the start of the `ReadBuf`
     #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut MaybeUninit<u8> {
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.buf.as_mut_ptr()
     }
 
@@ -70,35 +38,7 @@ impl<'a> ReadBuf<'a> {
     /// Returns a shared reference to the filled portion of the buffer.
     #[inline]
     pub fn filled(&self) -> &[u8] {
-        let slice = &self.buf[..self.filled];
-        // safety: filled describes how far into the buffer that the
-        // user has filled with bytes, so it's been initialized.
-        unsafe { slice_assume_init(slice) }
-    }
-
-    /// Returns a mutable reference to the entire buffer, without ensuring that it has been fully
-    /// initialized.
-    ///
-    /// The elements between 0 and `self.len()` are filled, and those between 0 and
-    /// `self.initialized().len()` are initialized (and so can be converted to a `&mut [u8]`).
-    ///
-    /// The caller of this method must ensure that these invariants are upheld. For example, if the
-    /// caller initializes some of the uninitialized section of the buffer, it must call
-    /// [`assume_init`](Self::assume_init) with the number of bytes initialized.
-    ///
-    /// # Safety
-    ///
-    /// The caller must not de-initialize portions of the buffer that have already been initialized.
-    /// This includes any bytes in the region marked as uninitialized by `ReadBuf`.
-    #[inline]
-    pub unsafe fn inner_mut(&mut self) -> &mut [MaybeUninit<u8>] {
-        self.buf
-    }
-
-    /// Returns the number of bytes at the end of the slice that have not yet been filled.
-    #[inline]
-    fn remaining(&self) -> usize {
-        self.capacity() - self.filled
+        &self.buf[..self.filled]
     }
 
     /// Clears the buffer, resetting the filled region to empty.
@@ -106,41 +46,39 @@ impl<'a> ReadBuf<'a> {
     /// The number of initialized bytes is not changed, and the contents of the buffer are not modified.
     #[inline]
     pub fn clear(&mut self) {
+        self.buf.fill(0);
         self.filled = 0;
     }
 
-    fn push_symbol(&mut self, a: u8, b: u8, c: u8) {
-        assert!(
-            self.remaining() >= 3,
-            "read_buf is full ({} bytes)",
-            self.capacity()
-        );
+    #[inline(always)]
+    pub fn push_lit(&mut self, byte: u8) {
+        // NOTE: we rely on the buffer being zeroed here!
+        self.buf[self.filled + 2] = byte;
 
-        self.buf[self.filled] = MaybeUninit::new(a);
-        self.buf[self.filled + 1] = MaybeUninit::new(b);
-        self.buf[self.filled + 2] = MaybeUninit::new(c);
-
-        self.initialized = Ord::max(self.initialized, self.filled + 3);
         self.filled += 3;
     }
 
-    pub fn push_lit(&mut self, byte: u8) {
-        self.push_symbol(0, 0, byte)
-    }
-
+    #[inline(always)]
     pub fn push_dist(&mut self, dist: u16, len: u8) {
+        let buf = &mut self.buf[self.filled..][..3];
         let [dist1, dist2] = dist.to_le_bytes();
-        self.push_symbol(dist1, dist2, len)
+
+        buf[0] = dist1;
+        buf[1] = dist2;
+        buf[2] = len;
+
+        self.filled += 3;
     }
 
     pub(crate) fn new_in(alloc: &Allocator<'a>, len: usize) -> Option<Self> {
         let buf = alloc.allocate_slice::<u8>(len)?;
 
-        Some(Self {
-            buf,
-            filled: 0,
-            initialized: 0,
-        })
+        buf.fill(MaybeUninit::new(0));
+
+        // safety: all elements are now initialized
+        let buf = unsafe { core::slice::from_raw_parts_mut(buf.as_mut_ptr().cast(), buf.len()) };
+
+        Some(Self { buf, filled: 0 })
     }
 
     pub(crate) fn clone_in(&self, alloc: &Allocator<'a>) -> Option<Self> {
@@ -148,7 +86,6 @@ impl<'a> ReadBuf<'a> {
 
         clone.buf.copy_from_slice(self.buf);
         clone.filled = self.filled;
-        clone.initialized = self.initialized;
 
         Some(clone)
     }
@@ -165,17 +102,7 @@ impl fmt::Debug for ReadBuf<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReadBuf")
             .field("filled", &self.filled)
-            .field("initialized", &self.initialized)
             .field("capacity", &self.capacity())
             .finish()
     }
-}
-
-unsafe fn slice_to_uninit_mut(slice: &mut [u8]) -> &mut [MaybeUninit<u8>] {
-    &mut *(slice as *mut [u8] as *mut [MaybeUninit<u8>])
-}
-
-// TODO: This could use `MaybeUninit::slice_assume_init` when it is stable.
-unsafe fn slice_assume_init(slice: &[MaybeUninit<u8>]) -> &[u8] {
-    &*(slice as *const [MaybeUninit<u8>] as *const [u8])
 }


### PR DESCRIPTION
much better than before

```
Benchmark 1 (33 runs): ./compress-baseline 3 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           155ms ± 3.30ms     150ms …  164ms          1 ( 3%)        0%
  peak_rss           24.7MB ± 67.7KB    24.5MB … 24.8MB          0 ( 0%)        0%
  cpu_cycles          671M  ± 12.2M      657M  …  704M           1 ( 3%)        0%
  instructions       1.71G  ±  238      1.71G  … 1.71G           0 ( 0%)        0%
  cache_references   43.8M  ±  552K     42.9M  … 45.1M           2 ( 6%)        0%
  cache_misses       1.16M  ±  300K      787K  … 1.99M           1 ( 3%)        0%
  branch_misses      7.79M  ± 9.15K     7.78M  … 7.81M           0 ( 0%)        0%
Benchmark 2 (36 runs): target/release/examples/blogpost-compress 3 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           140ms ± 1.83ms     138ms …  146ms          2 ( 6%)        ⚡-  9.8% ±  0.8%
  peak_rss           24.7MB ± 76.7KB    24.5MB … 24.8MB          0 ( 0%)          +  0.0% ±  0.1%
  cpu_cycles          616M  ± 5.98M      609M  …  636M           2 ( 6%)        ⚡-  8.1% ±  0.7%
  instructions       1.53G  ±  264      1.53G  … 1.53G           1 ( 3%)        ⚡- 10.6% ±  0.0%
  cache_references   43.9M  ±  524K     43.2M  … 45.3M           2 ( 6%)          +  0.3% ±  0.6%
  cache_misses       1.02M  ±  213K      744K  … 1.79M           1 ( 3%)        ⚡- 12.7% ± 10.7%
  branch_misses      7.79M  ± 5.34K     7.78M  … 7.80M           2 ( 6%)          +  0.0% ±  0.0%
```

but still a ways to go

```
Benchmark 1 (38 runs): target/release/examples/blogpost-compress 3 ng silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           131ms ± 1.58ms     129ms …  138ms          2 ( 5%)        0%
  peak_rss           24.7MB ± 58.5KB    24.6MB … 24.8MB          0 ( 0%)        0%
  cpu_cycles          575M  ± 6.40M      570M  …  601M           2 ( 5%)        0%
  instructions       1.30G  ±  239      1.30G  … 1.30G           0 ( 0%)        0%
  cache_references   41.2M  ±  513K     40.3M  … 42.5M           0 ( 0%)        0%
  cache_misses       1.31M  ±  314K      926K  … 2.50M           2 ( 5%)        0%
  branch_misses      7.70M  ± 5.63K     7.69M  … 7.72M           1 ( 3%)        0%
Benchmark 2 (36 runs): target/release/examples/blogpost-compress 3 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           140ms ± 1.42ms     138ms …  145ms          4 (11%)        💩+  6.9% ±  0.5%
  peak_rss           24.7MB ± 62.7KB    24.6MB … 24.8MB          0 ( 0%)          -  0.2% ±  0.1%
  cpu_cycles          617M  ± 5.97M      610M  …  637M           1 ( 3%)        💩+  7.1% ±  0.5%
  instructions       1.53G  ±  561      1.53G  … 1.53G           3 ( 8%)        💩+ 17.2% ±  0.0%
  cache_references   44.1M  ±  481K     43.3M  … 45.1M           0 ( 0%)        💩+  7.1% ±  0.6%
  cache_misses       1.07M  ±  212K      790K  … 1.54M           0 ( 0%)        ⚡- 18.3% ±  9.6%
  branch_misses      7.79M  ± 7.97K     7.78M  … 7.82M           3 ( 8%)        💩+  1.2% ±  0.0%
```

but, most of these changes are actually beneficial for all compression levels, so at the higher levels we're doing really well

```
Benchmark 2 (24 runs): target/release/examples/blogpost-compress 6 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           215ms ± 3.67ms     211ms …  227ms          2 ( 8%)        ⚡-  2.8% ±  0.9%
  peak_rss           24.5MB ±  116KB    24.2MB … 24.6MB          0 ( 0%)          +  0.0% ±  0.2%
  cpu_cycles          963M  ± 14.1M      949M  … 1.01G           1 ( 4%)        ⚡-  2.5% ±  0.7%
  instructions       1.93G  ±  364      1.93G  … 1.93G           2 ( 8%)        💩+ 17.7% ±  0.0%
  cache_references    105M  ± 1.10M      104M  …  108M           0 ( 0%)        💩+  3.3% ±  0.6%
  cache_misses       2.01M  ±  617K     1.36M  … 3.49M           0 ( 0%)          -  9.4% ± 13.8%
  branch_misses      9.25M  ± 9.71K     9.24M  … 9.27M           0 ( 0%)        💩+  4.1% ±  0.1%

Benchmark 2 (12 runs): target/release/examples/blogpost-compress 9 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           419ms ± 4.96ms     415ms …  428ms          0 ( 0%)        ⚡-  4.1% ±  0.7%
  peak_rss           24.4MB ± 81.5KB    24.2MB … 24.5MB          0 ( 0%)          -  0.1% ±  0.3%
  cpu_cycles         1.90G  ± 12.5M     1.89G  … 1.93G           1 ( 8%)        ⚡-  4.5% ±  0.4%
  instructions       3.18G  ±  398      3.18G  … 3.18G           0 ( 0%)        💩+ 12.7% ±  0.0%
  cache_references    195M  ±  955K      194M  …  198M           0 ( 0%)          +  1.1% ±  0.4%
  cache_misses       2.91M  ±  799K     1.80M  … 4.58M           0 ( 0%)          -  8.6% ± 18.4%
  branch_misses      19.1M  ± 48.8K     19.0M  … 19.2M           3 (25%)        ⚡-  8.3% ±  0.1%
``` 
