### PR TITLE
fuzzing: inflate fuzz suite for catching UB

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -185,9 +185,9 @@ jobs:
     strategy:
       matrix:
         features:
-          - ""
-          - '--no-default-features --features="c-allocator"'
-          - '--no-default-features --features="rust-allocator"'
+          - 'default'
+          - 'c-allocator'
+          - 'rust-allocator'
     steps:
       - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -203,9 +203,14 @@ jobs:
           tool: cargo-fuzz
       - name: Smoke-test fuzz targets
         run: |
-          cargo fuzz build ${{ matrix.features }}
-          for target in $(cargo fuzz list ${{ matrix.features }}) ; do
-            RUST_BACKTRACE=1 cargo fuzz run ${{ matrix.features }} $target -- -max_total_time=10
+          cargo fuzz build --no-default-features --features="${{ matrix.features }}"
+          for target in $(cargo fuzz list); do
+            if [ "$target" = "uncompress2" ]; then
+              features="${{ matrix.features }} disable-checksum"
+            else
+              features="${{ matrix.features }}"
+            fi
+            RUST_BACKTRACE=1 cargo fuzz run --no-default-features --features="$features" $target -- -max_total_time=10
           done
 
   fuzz-aarch64:
@@ -233,9 +238,14 @@ jobs:
           tool: cargo-fuzz
       - name: Smoke-test fuzz targets
         run: |
-          cargo fuzz build ${{ matrix.features }}
-          for target in $(cargo fuzz list ${{ matrix.features }}) ; do
-            RUST_BACKTRACE=1 cargo fuzz run ${{ matrix.features }} $target -- -max_total_time=10
+          cargo fuzz build --no-default-features --features="${{ matrix.features }}"
+          for target in $(cargo fuzz list); do
+            if [ "$target" = "uncompress2" ]; then
+              features="${{ matrix.features }} disable-checksum"
+            else
+              features="${{ matrix.features }}"
+            fi
+            RUST_BACKTRACE=1 cargo fuzz run --no-default-features --features="$features" $target -- -max_total_time=10
           done
 
   link-c-dynamic-library:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "zlib-rs-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true
@@ -15,6 +15,7 @@ debug = true
 default = ["rust-allocator", "libz-rs-sys/testing-prefix"]
 c-allocator = ["libz-rs-sys/c-allocator", "test-libz-rs-sys/c-allocator", "libz-rs-sys/std"]
 rust-allocator = ["libz-rs-sys/rust-allocator",  "test-libz-rs-sys/rust-allocator", "libz-rs-sys/std"]
+disable-checksum = ["zlib-rs/__internal-fuzz-disable-checksum"]
 
 [dependencies.libfuzzer-sys]
 version = "0.4"
@@ -25,6 +26,7 @@ libc = "0.2.151"
 libz-ng-sys = "1.1.12"
 libloading = "0.8.1"
 crc32fast = "1.3.2"
+rstest = "0.23.0"
 
 [dependencies.zlib-rs]
 path = "../zlib-rs"
@@ -47,6 +49,13 @@ name = "uncompress"
 path = "fuzz_targets/uncompress.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "uncompress2"
+path = "fuzz_targets/uncompress2.rs"
+test = true
+doc = false
+required-features = ["disable-checksum"]
 
 [[bin]]
 name = "uncompress_random_input"

--- a/fuzz/fuzz_targets/uncompress2.rs
+++ b/fuzz/fuzz_targets/uncompress2.rs
@@ -3,13 +3,23 @@
 //! coverage by disabling checksum validation and disregarding correctness of the results.
 //!
 //! This test must be run with `--features disable-checksum`. It's also suggested to initialize
-//! fuzzing with a corpus of real zlib/gzip files.
+//! fuzzing with a corpus of real zlib/gzip files. Place the corpus in directory
+//! `corpus/uncompress2` (the default corpus location).
+//!
+//! Then, the fuzzer can be run like:
+//!
+//! ```
+//! cargo fuzz run uncompress2 --features disable-checksum -j$(nproc)
+//! ```
+//!
+//! If not starting with an initial corpus, consider using the `-- -max_len=1048576` argument to
+//! test larger inputs.
 //!
 //! libfuzzer uses LLVM sanitizers to detect some classes of bugs and UB. For detecting
 //! Rust-specific UB, use Miri. Once a corpus with suitable coverage has been built, you can run
 //! Miri against the corpus by executing:
 //! ```
-//! MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --bin uncompress2
+//! MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --bin uncompress2 --features disable-checksum
 //! ```
 //! This assumes the corpus is located in the default directory of `corpus/uncompress2`. If it
 //! isn't, specify the corpus directory with the `ZLIB_RS_CORPUS_DIR` environment variable.

--- a/fuzz/fuzz_targets/uncompress2.rs
+++ b/fuzz/fuzz_targets/uncompress2.rs
@@ -1,0 +1,118 @@
+//! This fuzzer is intended to find memory safety bugs and undefined behavior. The input entire
+//! input is processed, allowing for analysis of files of arbitrary size. It also speeds up
+//! coverage by disabling checksum validation and disregarding correctness of the results.
+//!
+//! This test must be run with `--features disable-checksum`. It's also suggested to initialize
+//! fuzzing with a corpus of real zlib/gzip files.
+//!
+//! libfuzzer uses LLVM sanitizers to detect some classes of bugs and UB. For detecting
+//! Rust-specific UB, use Miri. Once a corpus with suitable coverage has been built, you can run
+//! Miri against the corpus by executing:
+//! ```
+//! MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --bin uncompress2
+//! ```
+//! This assumes the corpus is located in the default directory of `corpus/uncompress2`. If it
+//! isn't, specify the corpus directory with the `ZLIB_RS_CORPUS_DIR` environment variable.
+#![cfg_attr(not(any(miri, test)), no_main)]
+
+use libfuzzer_sys::{fuzz_target, Corpus};
+use libz_rs_sys::{
+    gz_header, inflate, inflateEnd, inflateGetHeader, inflateInit2_, z_stream, zlibVersion,
+};
+use zlib_rs::{InflateFlush, ReturnCode};
+
+fuzz_target!(|input: &[u8]| -> Corpus { run(input) });
+
+fn run(input: &[u8]) -> Corpus {
+    if input.is_empty() {
+        return Corpus::Reject;
+    }
+
+    let mut stream = z_stream::default();
+
+    let err = unsafe {
+        inflateInit2_(
+            &mut stream,
+            15 + 32, // Support both zlib and gzip files.
+            zlibVersion(),
+            size_of::<z_stream>() as _,
+        )
+    };
+    assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
+
+    let mut extra = vec![0; 64];
+    let mut name = vec![0; 64];
+    let mut comment = vec![0; 64];
+    let mut header = gz_header {
+        text: 0,
+        time: 0,
+        xflags: 0,
+        os: 0,
+        extra: extra.as_mut_ptr(),
+        extra_len: 0,
+        extra_max: 64,
+        name: name.as_mut_ptr(),
+        name_max: 64,
+        comment: comment.as_mut_ptr(),
+        comm_max: 64,
+        hcrc: 0,
+        done: 0,
+    };
+
+    let err = unsafe { inflateGetHeader(&mut stream, &mut header) };
+    assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
+
+    let mut output = vec![0; input.len()];
+    let input_len: u64 = input.len().try_into().unwrap();
+    stream.next_out = output.as_mut_ptr();
+    stream.avail_out = output.len().try_into().unwrap();
+    stream.next_in = input.as_ptr();
+    stream.avail_in = input.len().try_into().unwrap();
+
+    while input_len.checked_sub(stream.total_in).unwrap() > 0 {
+        let err = unsafe { inflate(&mut stream, InflateFlush::Finish as _) };
+        match ReturnCode::from(err) {
+            ReturnCode::StreamEnd => {
+                break;
+            }
+            ReturnCode::BufError | ReturnCode::Ok => {
+                let add_space: u32 = Ord::max(1024, output.len().try_into().unwrap());
+                output.extend(core::iter::repeat_n(0, add_space.try_into().unwrap()));
+
+                // If extend() reallocates, it may have moved in memory.
+                stream.next_out = output.as_mut_ptr();
+                stream.avail_out += add_space;
+            }
+            _ => {
+                unsafe { inflateEnd(&mut stream) };
+                return Corpus::Reject;
+            }
+        }
+    }
+
+    let err = unsafe { inflateEnd(&mut stream) };
+    match ReturnCode::from(err) {
+        ReturnCode::Ok => Corpus::Keep,
+        _ => Corpus::Reject,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(miri)]
+    use {
+        crate::run,
+        rstest::rstest,
+        std::{fs::File, io::Read, path::PathBuf},
+    };
+
+    #[rstest]
+    #[cfg(miri)]
+    fn miri_corpus(#[files("${ZLIB_RS_CORPUS_DIR:-corpus/uncompress2}/*")] path: PathBuf) {
+        let mut input = File::open(path).unwrap();
+        let mut buf = Vec::new();
+        input.read_to_end(&mut buf).unwrap();
+
+        run(&buf);
+    }
+}

--- a/fuzz/fuzz_targets/uncompress2.rs
+++ b/fuzz/fuzz_targets/uncompress2.rs
@@ -77,9 +77,9 @@ fn run(input: &[u8]) -> Corpus {
             }
             ReturnCode::BufError | ReturnCode::Ok => {
                 let add_space: u32 = Ord::max(1024, output.len().try_into().unwrap());
-                output.extend(core::iter::repeat_n(0, add_space.try_into().unwrap()));
+                output.resize(output.len() + add_space as usize, 0);
 
-                // If extend() reallocates, it may have moved in memory.
+                // If resize() reallocates, it may have moved in memory.
                 stream.next_out = output.as_mut_ptr();
                 stream.avail_out += add_space;
             }

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -18,6 +18,7 @@ std = ["rust-allocator"]
 c-allocator = [] # expose a malloc-based C allocator
 rust-allocator = [] # expose a rust global alloctor
 __internal-fuzz = ["arbitrary"]
+__internal-fuzz-disable-checksum = [] # disable checksum validation on inflate
 __internal-test = ["quickcheck"]
 ZLIB_DEBUG = []
 

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -914,7 +914,7 @@ impl<'a> State<'a> {
     }
 
     fn check(&mut self) -> ReturnCode {
-        if self.wrap != 0 {
+        if !cfg!(feature = "__internal-fuzz-disable-checksum") && self.wrap != 0 {
             need_bits!(self, 32);
 
             self.total += self.writer.len();


### PR DESCRIPTION
This suite is mainly intended to catch memory safety bugs and undefined behavior on the inflate code path. To that end it eschews the correctness checks present in other fuzz targets.

It also supports easily running Miri against the generated corpus, to catch any Rust-specific UB that wouldn't be caught by the other LLVM sanitizers.