### PR TITLE
Miri stacked borrows improvements for inflate

### DIFF
--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -226,6 +226,16 @@ impl<'a> Allocator<'a> {
         ptr
     }
 
+    pub fn allocate_raw<T>(&self) -> Option<*mut T> {
+        let ptr = self.allocate_layout(Layout::new::<T>());
+
+        if ptr.is_null() {
+            None
+        } else {
+            Some(ptr as *mut T)
+        }
+    }
+
     pub fn allocate<T>(&self) -> Option<&'a mut MaybeUninit<T>> {
         let ptr = self.allocate_layout(Layout::new::<T>());
 

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1889,9 +1889,9 @@ pub fn reset_with_config(stream: &mut InflateStream, config: InflateConfig) -> R
         let mut window = Window::empty();
         core::mem::swap(&mut window, &mut stream.state.window);
 
-        let window = window.into_inner();
-        assert!(!window.is_empty());
-        unsafe { stream.alloc.deallocate(window.as_mut_ptr(), window.len()) };
+        let (ptr, len) = window.into_raw_parts();
+        assert_ne!(len, 0);
+        unsafe { stream.alloc.deallocate(ptr, len) };
     }
 
     stream.state.wrap = wrap as u8;
@@ -2282,8 +2282,8 @@ pub fn end<'a>(stream: &'a mut InflateStream<'a>) -> &'a mut z_stream {
 
     // safety: window is not used again
     if !window.is_empty() {
-        let window = window.into_inner();
-        unsafe { alloc.deallocate(window.as_mut_ptr(), window.len()) };
+        let (ptr, len) = window.into_raw_parts();
+        unsafe { alloc.deallocate(ptr, len) };
     }
 
     let stream = stream.as_z_stream_mut();

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -2301,7 +2301,7 @@ pub fn end<'a>(stream: &'a mut InflateStream<'a>) -> &'a mut z_stream {
 /// The caller must guarantee:
 ///
 /// * If `head` is `Some`:
-//      - If `head.extra` is not NULL, it must be writable for at least `head.extra_max` bytes
+///     - If `head.extra` is not NULL, it must be writable for at least `head.extra_max` bytes
 ///     - if `head.name` is not NULL, it must be writable for at least `head.name_max` bytes
 ///     - if `head.comment` is not NULL, it must be writable for at least `head.comm_max` bytes
 pub unsafe fn get_header<'a>(

--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -25,12 +25,12 @@ impl<'a> BitReader<'a> {
     }
 
     #[inline(always)]
-    pub fn update_slice(&mut self, slice: &[u8]) {
-        let range = slice.as_ptr_range();
+    pub unsafe fn update_slice(&mut self, ptr: *const u8, len: usize) {
+        let end = ptr.wrapping_add(len);
 
         *self = Self {
-            ptr: range.start,
-            end: range.end,
+            ptr,
+            end,
             bit_buffer: self.bit_buffer,
             bits_used: self.bits_used,
             _marker: PhantomData,

--- a/zlib-rs/src/lib.rs
+++ b/zlib-rs/src/lib.rs
@@ -12,6 +12,7 @@ pub mod crc32;
 pub mod deflate;
 pub mod inflate;
 pub mod read_buf;
+mod weak_slice;
 
 pub use adler32::{adler32, adler32_combine};
 pub use crc32::{crc32, crc32_combine};

--- a/zlib-rs/src/weak_slice.rs
+++ b/zlib-rs/src/weak_slice.rs
@@ -1,0 +1,61 @@
+use core::marker::PhantomData;
+
+/// a mutable "slice" (bundle of pointer and length). The main goal of this type is passing MIRI
+/// with stacked borrows. In particular, storing a standard slice in data structures violates the
+/// stacked borrows rule when that slice is deallocated. By only materializing the slice when
+/// needed for data access, hence bounding the lifetime more tightly, this restriction is circumvented.
+#[derive(Debug)]
+pub(crate) struct WeakSliceMut<'a, T> {
+    ptr: *mut T,
+    len: usize,
+    _marker: PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> WeakSliceMut<'a, T> {
+    /// # Safety
+    ///
+    /// The arguments must satisfy the requirements of [`core::slice::from_raw_parts_mut`]. The
+    /// difference versus a slice is that the slice requirements are only enforced when a slice is
+    /// needed, so in practice we mostly get the bounds checking and other convenient slice APIs,
+    /// without the exact correctness constraints of a rust core/std slice.
+    pub(crate) unsafe fn from_raw_parts_mut(ptr: *mut T, len: usize) -> Self {
+        Self {
+            ptr,
+            len,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn into_raw_parts(self) -> (*mut T, usize) {
+        (self.ptr, self.len)
+    }
+
+    pub(crate) fn as_slice(&self) -> &'a [T] {
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
+    }
+
+    pub(crate) fn as_mut_slice(&mut self) -> &'a mut [T] {
+        unsafe { core::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut T {
+        self.ptr
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn empty() -> Self {
+        let buf = &mut [];
+        Self {
+            ptr: buf.as_mut_ptr(),
+            len: buf.len(),
+            _marker: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
working towards fixing https://github.com/trifectatechfoundation/zlib-rs/issues/233

this now works with stacked borrows (the default)

```
cargo +nightly miri nextest run -p test-libz-rs-sys inflate::
```

cc @inahga 