### PR TITLE
run deflate tests under stacked borrows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -354,8 +354,5 @@ jobs:
         run: "cargo +nightly miri nextest run -j4 -p test-libz-rs-sys null::"
         env:
           RUSTFLAGS: "-Ctarget-feature=+avx2"
-          MIRIFLAGS: "-Zmiri-tree-borrows"
       - name: Test allocator with miri
         run: "cargo +nightly miri nextest run -j4 -p zlib-rs allocate::"
-        env:
-          MIRIFLAGS: "-Zmiri-tree-borrows"

--- a/test-libz-rs-sys/src/deflate.rs
+++ b/test-libz-rs-sys/src/deflate.rs
@@ -1849,7 +1849,7 @@ mod fuzz_based_tests {
                 mem_level: 2,
                 strategy: Strategy::Default,
             },
-            if cfg!(any(target_arch = "s390x", target_family = "wasm")) {
+            if cfg!(any(miri, target_arch = "s390x", target_family = "wasm")) {
                 output_s390x
             } else {
                 output_other

--- a/test-libz-rs-sys/src/deflate.rs
+++ b/test-libz-rs-sys/src/deflate.rs
@@ -189,11 +189,12 @@ pub mod quick {
 
         stream.next_in = &BLOCK_OPEN_INPUT as *const u8 as *mut u8;
         let mut next_out = [0u8; 1116];
+        let next_out_start = next_out.as_ptr() as usize;
         stream.next_out = next_out.as_mut_ptr();
 
         stream.avail_in = BLOCK_OPEN_INPUT.len() as _;
         loop {
-            let written = stream.next_out as usize - next_out.as_mut_ptr() as usize;
+            let written = stream.next_out as usize - next_out_start;
             stream.avail_out = (next_out.len() - written) as _;
 
             if stream.avail_out > 38 {
@@ -287,11 +288,12 @@ pub mod quick {
 
         stream.next_in = &BLOCK_OPEN_INPUT as *const u8 as *mut u8;
         let mut next_out = [0u8; 1116];
+        let next_out_start = next_out.as_ptr() as usize;
         stream.next_out = next_out.as_mut_ptr();
 
         stream.avail_in = BLOCK_OPEN_INPUT.len() as _;
         loop {
-            let written = stream.next_out as usize - next_out.as_mut_ptr() as usize;
+            let written = stream.next_out as usize - next_out_start;
             stream.avail_out = (next_out.len() - written) as _;
 
             if stream.avail_out > 38 {
@@ -306,7 +308,7 @@ pub mod quick {
             assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
         }
 
-        let compressed_size = stream.next_out as usize - next_out.as_mut_ptr() as usize;
+        let compressed_size = stream.next_out as usize - next_out_start;
 
         let err = unsafe { deflateEnd(&mut stream) };
         assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
@@ -385,11 +387,12 @@ pub mod quick {
 
         stream.next_in = &BLOCK_OPEN_INPUT as *const u8 as *mut u8;
         let mut next_out = [0u8; 1116];
+        let next_out_start = next_out.as_ptr() as usize;
         stream.next_out = next_out.as_mut_ptr();
 
         stream.avail_in = BLOCK_OPEN_INPUT.len() as _;
         loop {
-            let written = stream.next_out as usize - next_out.as_mut_ptr() as usize;
+            let written = stream.next_out as usize - next_out_start;
             stream.avail_out = (next_out.len() - written) as _;
 
             if stream.avail_out > 38 {
@@ -404,7 +407,7 @@ pub mod quick {
             assert_eq!(ReturnCode::from(err), ReturnCode::Ok);
         }
 
-        let compressed_size = stream.next_out as usize - next_out.as_mut_ptr() as usize;
+        let compressed_size = stream.next_out as usize - next_out_start;
 
         let err = unsafe { deflateEnd(&mut stream) };
         assert_eq!(ReturnCode::from(err), ReturnCode::Ok);

--- a/test-libz-rs-sys/src/end_to_end.rs
+++ b/test-libz-rs-sys/src/end_to_end.rs
@@ -3,6 +3,7 @@ use zlib_rs::{deflate::DeflateConfig, inflate::InflateConfig, ReturnCode};
 use crate::helpers::{compress_slice_ng, uncompress_slice_ng};
 
 #[test]
+#[cfg_attr(miri, ignore = "calls into C code")]
 fn end_to_end() {
     ::quickcheck::quickcheck(test as fn(_, _) -> _);
 }

--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -356,13 +356,13 @@ mod tests {
                 _marker: PhantomData,
             };
 
-            let ptr = allocator.allocate::<T>().unwrap();
-            assert_eq!(ptr.as_ptr() as usize % core::mem::align_of::<T>(), 0);
+            let ptr = allocator.allocate_raw::<T>().unwrap();
+            assert_eq!(ptr as usize % core::mem::align_of::<T>(), 0);
             unsafe { allocator.deallocate(ptr, 1) }
 
-            let ptr = allocator.allocate_slice::<T>(10).unwrap();
-            assert_eq!(ptr.as_ptr() as usize % core::mem::align_of::<T>(), 0);
-            unsafe { allocator.deallocate(ptr.as_mut_ptr(), 10) }
+            let ptr = allocator.allocate_slice_raw::<T>(10).unwrap();
+            assert_eq!(ptr as usize % core::mem::align_of::<T>(), 0);
+            unsafe { allocator.deallocate(ptr, 10) }
         }
     }
 

--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -236,6 +236,16 @@ impl<'a> Allocator<'a> {
         }
     }
 
+    pub fn allocate_slice_raw<T>(&self, len: usize) -> Option<*mut T> {
+        let ptr = self.allocate_layout(Layout::array::<T>(len).ok()?);
+
+        if ptr.is_null() {
+            None
+        } else {
+            Some(ptr.cast())
+        }
+    }
+
     pub fn allocate<T>(&self) -> Option<&'a mut MaybeUninit<T>> {
         let ptr = self.allocate_layout(Layout::new::<T>());
 

--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -4,7 +4,6 @@ use core::{
     alloc::Layout,
     ffi::{c_uint, c_void},
     marker::PhantomData,
-    mem::MaybeUninit,
 };
 
 #[cfg(feature = "rust-allocator")]
@@ -243,26 +242,6 @@ impl<'a> Allocator<'a> {
             None
         } else {
             Some(ptr.cast())
-        }
-    }
-
-    pub fn allocate<T>(&self) -> Option<&'a mut MaybeUninit<T>> {
-        let ptr = self.allocate_layout(Layout::new::<T>());
-
-        if ptr.is_null() {
-            None
-        } else {
-            Some(unsafe { &mut *(ptr as *mut MaybeUninit<T>) })
-        }
-    }
-
-    pub fn allocate_slice<T>(&self, len: usize) -> Option<&'a mut [MaybeUninit<T>]> {
-        let ptr = self.allocate_layout(Layout::array::<T>(len).ok()?);
-
-        if ptr.is_null() {
-            None
-        } else {
-            Some(unsafe { core::slice::from_raw_parts_mut(ptr.cast(), len) })
         }
     }
 

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -50,10 +50,10 @@ impl StandardHashCalc {
 
         let hm = Self::update_hash(0, val) as usize;
 
-        let head = state.head[hm];
+        let head = state.head.as_slice()[hm];
         if head != string as u16 {
-            state.prev[string & state.w_mask] = head;
-            state.head[hm] = string as u16;
+            state.prev.as_mut_slice()[string & state.w_mask] = head;
+            state.head.as_mut_slice()[hm] = string as u16;
         }
 
         head
@@ -73,10 +73,10 @@ impl StandardHashCalc {
 
             let hm = Self::update_hash(0, val) as usize;
 
-            let head = state.head[hm];
+            let head = state.head.as_slice()[hm];
             if head != idx {
-                state.prev[idx as usize & state.w_mask] = head;
-                state.head[hm] = idx;
+                state.prev.as_mut_slice()[idx as usize & state.w_mask] = head;
+                state.head.as_mut_slice()[hm] = idx;
             }
         }
     }
@@ -106,10 +106,10 @@ impl RollHashCalc {
 
         let hm = state.ins_h;
 
-        let head = state.head[hm];
+        let head = state.head.as_slice()[hm];
         if head != string as u16 {
-            state.prev[string & state.w_mask] = head;
-            state.head[hm] = string as u16;
+            state.prev.as_mut_slice()[string & state.w_mask] = head;
+            state.head.as_mut_slice()[hm] = string as u16;
         }
 
         head
@@ -125,10 +125,10 @@ impl RollHashCalc {
             state.ins_h &= Self::HASH_CALC_MASK as usize;
             let hm = state.ins_h;
 
-            let head = state.head[hm];
+            let head = state.head.as_slice()[hm];
             if head != idx {
-                state.prev[idx as usize & state.w_mask] = head;
-                state.head[hm] = idx;
+                state.prev.as_mut_slice()[idx as usize & state.w_mask] = head;
+                state.head.as_mut_slice()[hm] = idx;
             }
         }
     }
@@ -193,10 +193,10 @@ impl Crc32HashCalc {
 
         let hm = unsafe { Self::update_hash(0, val) } as usize;
 
-        let head = state.head[hm];
+        let head = state.head.as_slice()[hm];
         if head != string as u16 {
-            state.prev[string & state.w_mask] = head;
-            state.head[hm] = string as u16;
+            state.prev.as_mut_slice()[string & state.w_mask] = head;
+            state.head.as_mut_slice()[hm] = string as u16;
         }
 
         head
@@ -219,10 +219,10 @@ impl Crc32HashCalc {
 
             let hm = unsafe { Self::update_hash(0, val) } as usize;
 
-            let head = state.head[hm];
+            let head = state.head.as_slice()[hm];
             if head != idx {
-                state.prev[idx as usize & state.w_mask] = head;
-                state.head[hm] = idx;
+                state.prev.as_mut_slice()[idx as usize & state.w_mask] = head;
+                state.head.as_mut_slice()[hm] = idx;
             }
         }
     }

--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -55,7 +55,7 @@ fn longest_match_help<const SLOW: bool>(
         () => {
             chain_length -= 1;
             if chain_length > 0 {
-                cur_match = state.prev[cur_match as usize & wmask];
+                cur_match = state.prev.as_slice()[cur_match as usize & wmask];
 
                 if cur_match > limit {
                     continue;
@@ -132,7 +132,7 @@ fn longest_match_help<const SLOW: bool>(
                 hash = state.update_hash(hash, *b as u32);
 
                 /* If we're starting with best_len >= 3, we can use offset search. */
-                pos = state.head[hash as usize];
+                pos = state.head.as_slice()[hash as usize];
                 if pos < cur_match {
                     match_offset = (i + 1) as Pos;
                     cur_match = pos;
@@ -300,7 +300,7 @@ fn longest_match_help<const SLOW: bool>(
                 let mut next_pos = cur_match;
 
                 for i in 0..=len - STD_MIN_MATCH {
-                    pos = state.prev[(cur_match as usize + i) & wmask];
+                    pos = state.prev.as_slice()[(cur_match as usize + i) & wmask];
                     if pos < next_pos {
                         /* Hash chain is more distant, use it */
                         if pos <= limit_base + i as Pos {
@@ -327,7 +327,7 @@ fn longest_match_help<const SLOW: bool>(
                 hash = state.update_hash(hash, scan1 as u32);
                 hash = state.update_hash(hash, scan2 as u32);
 
-                pos = state.head[hash as usize];
+                pos = state.head.as_slice()[hash as usize];
                 if pos < cur_match {
                     match_offset = (len - (STD_MIN_MATCH + 1)) as Pos;
                     if pos <= limit_base + match_offset {

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -1,8 +1,8 @@
 pub fn slide_hash(state: &mut crate::deflate::State) {
     let wsize = state.w_size as u16;
 
-    slide_hash_chain(state.head, wsize);
-    slide_hash_chain(state.prev, wsize);
+    slide_hash_chain(state.head.as_mut_slice(), wsize);
+    slide_hash_chain(state.prev.as_mut_slice(), wsize);
 }
 
 fn slide_hash_chain(table: &mut [u16], wsize: u16) {

--- a/zlib-rs/src/inflate/window.rs
+++ b/zlib-rs/src/inflate/window.rs
@@ -30,7 +30,7 @@ impl<'a> Window<'a> {
 
     pub fn size(&self) -> usize {
         // `self.len == 0` is used for uninitialized buffers
-        assert!(self.buf.len() == 0 || self.buf.len() >= Self::padding());
+        assert!(self.buf.is_empty() || self.buf.len() >= Self::padding());
         self.buf.len().saturating_sub(Self::padding())
     }
 

--- a/zlib-rs/src/weak_slice.rs
+++ b/zlib-rs/src/weak_slice.rs
@@ -50,6 +50,10 @@ impl<'a, T> WeakSliceMut<'a, T> {
         self.len
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub(crate) fn empty() -> Self {
         let buf = &mut [];
         Self {

--- a/zlib-rs/src/weak_slice.rs
+++ b/zlib-rs/src/weak_slice.rs
@@ -63,3 +63,30 @@ impl<'a, T> WeakSliceMut<'a, T> {
         }
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct WeakArrayMut<'a, T, const N: usize> {
+    ptr: *mut [T; N],
+    _marker: PhantomData<&'a mut [T; N]>,
+}
+
+impl<'a, T, const N: usize> WeakArrayMut<'a, T, N> {
+    pub(crate) unsafe fn from_ptr(ptr: *mut [T; N]) -> Self {
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &'a [T] {
+        unsafe { core::slice::from_raw_parts(self.ptr.cast(), N) }
+    }
+
+    pub(crate) fn as_mut_slice(&mut self) -> &'a mut [T] {
+        unsafe { core::slice::from_raw_parts_mut(self.ptr.cast(), N) }
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut [T; N] {
+        self.ptr
+    }
+}

--- a/zlib-rs/src/weak_slice.rs
+++ b/zlib-rs/src/weak_slice.rs
@@ -71,6 +71,9 @@ pub(crate) struct WeakArrayMut<'a, T, const N: usize> {
 }
 
 impl<'a, T, const N: usize> WeakArrayMut<'a, T, N> {
+    /// # Safety
+    ///
+    /// The pointer must be [convertable to a reference](https://doc.rust-lang.org/std/ptr/index.html#pointer-to-reference-conversion).
     pub(crate) unsafe fn from_ptr(ptr: *mut [T; N]) -> Self {
         Self {
             ptr,


### PR DESCRIPTION
we now pass the `zlib-rs` and `test-libz-rs-sys` tests under miri with (the default) stacked borrows :tada: 

cc @inahga 