### PR TITLE
longest_match: handle underflow in assertion

### DIFF
--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -157,7 +157,7 @@ fn longest_match_help<const SLOW: bool>(
     }
 
     assert!(
-        strstart <= state.window_size - MIN_LOOKAHEAD,
+        strstart <= state.window_size.saturating_sub(MIN_LOOKAHEAD),
         "need lookahead"
     );
 


### PR DESCRIPTION
Paranoia: this subtraction could underflow in release builds if window_size is small. 

This assertion isn't hit in practice, but this makes the unchecked slice reads later on in this function a little bit more palatable.