### PR TITLE
deflate: safety documentation, relax safety requirements of wasm intrinsics

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -2753,7 +2753,7 @@ pub fn compress_slice_with_flush<'a>(
     config: DeflateConfig,
     flush: DeflateFlush,
 ) -> (&'a mut [u8], ReturnCode) {
-    // SAFETY: a [u8] is a valid [MaybeUninit<u8>].
+    // SAFETY: a [u8] is a valid [MaybeUninit<u8>], and `compress_with_flush` never uninitializes previously initialized memory.
     let output_uninit = unsafe {
         core::slice::from_raw_parts_mut(output.as_mut_ptr() as *mut MaybeUninit<u8>, output.len())
     };

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -1,9 +1,12 @@
-#![warn(unsafe_op_in_unsafe_fn)]
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
 #[derive(Debug, Clone, Copy)]
 pub enum HashCalcVariant {
     Standard,
+    /// # Safety
+    ///
+    /// This variant should only be used on supported systems, checked at runtime. See
+    /// [`Crc32HashCalc`].
     Crc32,
     Roll,
 }
@@ -134,6 +137,11 @@ impl RollHashCalc {
     }
 }
 
+/// # Safety
+///
+/// The methods of this struct can only be executed if the system has platform support, otherwise
+/// the result is UB. Use [`Self::is_supported()`] to check at runtime whether the system has
+/// support before executing any methods.
 pub struct Crc32HashCalc;
 
 impl Crc32HashCalc {

--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -173,17 +173,22 @@ fn longest_match_help<const SLOW: bool>(
         // that depend on those values. However the length of the match is limited to the
         // lookahead, so the output of deflate is not affected by the uninitialized values.
 
-        // # Safety
-        //
-        // The two pointers must be valid for reads of N bytes.
+        /// # Safety
+        ///
+        /// The two pointers must be valid for reads of N bytes.
         #[inline(always)]
         unsafe fn memcmp_n_ptr<const N: usize>(src0: *const u8, src1: *const u8) -> bool {
-            let src0_cmp = core::ptr::read(src0 as *const [u8; N]);
-            let src1_cmp = core::ptr::read(src1 as *const [u8; N]);
-
-            src0_cmp == src1_cmp
+            unsafe {
+                let src0_cmp = core::ptr::read(src0 as *const [u8; N]);
+                let src1_cmp = core::ptr::read(src1 as *const [u8; N]);
+                src0_cmp == src1_cmp
+            }
         }
 
+        /// # Safety
+        ///
+        /// scan_start and scan_end must be valid for reads of N bytes. mbase_end and mbase_start
+        /// must be valid for reads of N + cur_match bytes.
         #[inline(always)]
         unsafe fn is_match<const N: usize>(
             cur_match: u16,
@@ -194,12 +199,14 @@ fn longest_match_help<const SLOW: bool>(
         ) -> bool {
             let be = mbase_end.wrapping_add(cur_match as usize);
             let bs = mbase_start.wrapping_add(cur_match as usize);
-
-            memcmp_n_ptr::<N>(be, scan_end) && memcmp_n_ptr::<N>(bs, scan_start)
+            unsafe { memcmp_n_ptr::<N>(be, scan_end) && memcmp_n_ptr::<N>(bs, scan_start) }
         }
 
         // first, do a quick check on the start and end bytes. Go to the next item in the chain if
         // these bytes don't match.
+        // SAFETY: we read up to 8 bytes in this block. scan_start and start_end are 8 byte arrays.
+        // this loop also breaks before cur_match gets past strstart, which is bounded by
+        // window_size - MIN_LOOKAHEAD, so 8 byte reads of mbase_end/start are in-bounds.
         unsafe {
             let scan_start = scan_start.as_ptr();
             let scan_end = scan_end.as_ptr();
@@ -248,9 +255,11 @@ fn longest_match_help<const SLOW: bool>(
 
         // we know that there is at least some match. Now count how many bytes really match
         let len = {
-            // TODO this just looks so incredibly unsafe!
-            let src1: &[u8; 256] =
-                unsafe { &*mbase_start.wrapping_add(cur_match as usize + 2).cast() };
+            // SAFETY: cur_match is bounded by window_size - MIN_LOOKAHEAD, where MIN_LOOKAHEAD
+            // is 256 + 2, so 258-byte reads of mbase_start are in-bounds.
+            let src1 = unsafe {
+                core::slice::from_raw_parts(mbase_start.wrapping_add(cur_match as usize + 2), 256)
+            };
 
             crate::deflate::compare256::compare256_slice(&scan[2..], src1) + 2
         };

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -32,6 +32,9 @@ mod rust {
     }
 }
 
+/// # Safety
+///
+/// These functions should only be executed on `aarch64` systems with the `neon` feature enabled.
 #[cfg(target_arch = "aarch64")]
 mod neon {
     use core::arch::aarch64::{
@@ -43,6 +46,9 @@ mod neon {
         unsafe { slide_hash_chain_internal(table, wsize) }
     }
 
+    /// # Safety
+    ///
+    /// Behavior is undefined if the `neon` target feature is not enabled
     #[target_feature(enable = "neon")]
     unsafe fn slide_hash_chain_internal(table: &mut [u16], wsize: u16) {
         debug_assert_eq!(table.len() % 32, 0);
@@ -58,14 +64,19 @@ mod neon {
         }
     }
 
+    /// # Safety
+    ///
+    /// Behavior is undefined if the `neon` target feature is not enabled
     #[target_feature(enable = "neon")]
     unsafe fn vqsubq_u16_x4_x1(a: uint16x8x4_t, b: uint16x8_t) -> uint16x8x4_t {
-        uint16x8x4_t(
-            vqsubq_u16(a.0, b),
-            vqsubq_u16(a.1, b),
-            vqsubq_u16(a.2, b),
-            vqsubq_u16(a.3, b),
-        )
+        unsafe {
+            uint16x8x4_t(
+                vqsubq_u16(a.0, b),
+                vqsubq_u16(a.1, b),
+                vqsubq_u16(a.2, b),
+                vqsubq_u16(a.3, b),
+            )
+        }
     }
 }
 
@@ -80,6 +91,9 @@ mod avx2 {
         unsafe { slide_hash_chain_internal(table, wsize) }
     }
 
+    /// # Safety
+    ///
+    /// Behavior is undefined if the `avx` target feature is not enabled
     #[target_feature(enable = "avx2")]
     unsafe fn slide_hash_chain_internal(table: &mut [u16], wsize: u16) {
         debug_assert_eq!(table.len() % 16, 0);
@@ -104,24 +118,26 @@ mod wasm {
 
     pub fn slide_hash_chain(table: &mut [u16], wsize: u16) {
         assert_eq!(table.len() % 8, 0);
-        unsafe { slide_hash_chain_internal(table, wsize) }
+        slide_hash_chain_internal(table, wsize)
     }
 
     #[target_feature(enable = "simd128")]
-    unsafe fn slide_hash_chain_internal(table: &mut [u16], wsize: u16) {
+    fn slide_hash_chain_internal(table: &mut [u16], wsize: u16) {
         let wsize_v128 = u16x8_splat(wsize);
 
         for chunk in table.chunks_exact_mut(8) {
             let chunk_ptr = chunk.as_mut_ptr() as *mut v128;
 
-            // Load the 128-bit value
-            let value = v128_load(chunk_ptr);
+            // Load the 128-bit value.
+            // SAFETY: the pointer we get from chunks_exact_mut() is valid.
+            let value = unsafe { v128_load(chunk_ptr) };
 
             // Perform saturating subtraction
             let result = u16x8_sub_sat(value, wsize_v128);
 
-            // Store the result back
-            v128_store(chunk_ptr, result);
+            // Store the result back.
+            // SAFETY: the pointer we get from chunks_exact_mut() is valid.
+            unsafe { v128_store(chunk_ptr, result) };
         }
     }
 }


### PR DESCRIPTION
Mostly documentation and noise from `#![warn(unsafe_op_in_unsafe_fn]`.

For WASM intrinsics, it is not UB if the system doesn't support the target feature, because WASM interpreters simply won't load binaries that contain unknown instructions. So we can relax the safety requirements accordingly.