### PR TITLE
inflate/bitreader: fix unsoundness in advance()

### DIFF
--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -39,7 +39,7 @@ impl<'a> BitReader<'a> {
 
     #[inline(always)]
     pub fn advance(&mut self, bytes: usize) {
-        self.ptr = Ord::min(unsafe { self.ptr.add(bytes) }, self.end);
+        self.ptr = Ord::min(self.ptr.wrapping_add(bytes), self.end);
     }
 
     #[inline(always)]


### PR DESCRIPTION
`BitReader::advance()` is unsound: if `bytes` is too large, we invoke UB in `self.ptr.add(bytes)` by advancing the pointer out of bounds of the allocated area. This doesn't happen in practice, since all uses of `advance()` are bounds checking with `BitReader::bytes_available()`, but we can make this API safer.

Use `.wrapping_add()` instead, which is safe for all inputs. The docs for it claim that `.add()` opens up more optimization opportunities. However, the generated assembly on x86_64 and aarch64 in release mode appear to be exactly the same, so I don't think we're losing out on anything here. (The guaranteed zero-cost way to fix this would be to just make `advance()` unsafe and document the invariant).