### PR TITLE
libz-rs-sys: more safety requirements on inflate() and deflate()

### DIFF
--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -314,6 +314,12 @@ pub unsafe extern "C-unwind" fn uncompress(
 /// * Either
 ///     - `strm` is `NULL`
 ///     - `strm` satisfies the requirements of `&mut *strm` and was initialized with [`inflateInit_`] or similar
+/// * Either
+///     - `strm.next_out` is `NULL`
+///     - `strm.next_out` and `strm.avail_out` satisfy the requirements of [`core::slice::from_raw_parts_mut::<MaybeUninit<u8>>`]
+/// * Either
+///     - `strm.next_in` is `NULL`
+///     - `strm.next_in` and `strm.avail_in` satisfy the requirements of [`core::slice::from_raw_parts::<u8>`]
 #[export_name = prefix!(inflate)]
 pub unsafe extern "C-unwind" fn inflate(strm: *mut z_stream, flush: i32) -> i32 {
     if let Some(stream) = InflateStream::from_stream_mut(strm) {
@@ -887,6 +893,12 @@ pub unsafe extern "C-unwind" fn inflateCodesUsed(_strm: *mut z_stream) -> c_ulon
 /// * Either
 ///     - `strm` is `NULL`
 ///     - `strm` satisfies the requirements of `&mut *strm` and was initialized with [`deflateInit_`] or similar
+/// * Either
+///     - `strm.next_out` is `NULL`
+///     - `strm.next_out` and `strm.avail_out` satisfy the requirements of [`core::slice::from_raw_parts_mut::<MaybeUninit<u8>>`]
+/// * Either
+///     - `strm.next_in` is `NULL`
+///     - `strm.next_in` and `strm.avail_in` satisfy the requirements of [`core::slice::from_raw_parts::<u8>`]
 #[export_name = prefix!(deflate)]
 pub unsafe extern "C-unwind" fn deflate(strm: *mut z_stream, flush: i32) -> c_int {
     if let Some(stream) = DeflateStream::from_stream_mut(strm) {


### PR DESCRIPTION
The in/out pointers in strm need to be well-formed, and those requirements weren't captured in the safety docs.