### PR TITLE
Inline the fast path of BitWriter::send_bits

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -974,16 +974,10 @@ impl<'a> BitWriter<'a> {
         self.send_bits_trace(val, len);
         self.sent_bits_add(len as usize);
 
+        self.bit_buffer |= val << self.bits_used;
         if total_bits < Self::BIT_BUF_SIZE {
-            self.bit_buffer |= val << self.bits_used;
             self.bits_used = total_bits;
-        } else if self.bits_used == Self::BIT_BUF_SIZE {
-            // with how send_bits is called, this is unreachable in practice
-            self.pending.extend(&self.bit_buffer.to_le_bytes());
-            self.bit_buffer = val;
-            self.bits_used = len;
         } else {
-            self.bit_buffer |= val << self.bits_used;
             self.pending.extend(&self.bit_buffer.to_le_bytes());
             self.bit_buffer = val >> (Self::BIT_BUF_SIZE - self.bits_used);
             self.bits_used = total_bits - Self::BIT_BUF_SIZE;


### PR DESCRIPTION
The "equal" and "greater" branches yield the same result when total_bits == Self::BIT_BUF_SIZE, so this change combines them to eliminate one conditional branch whenever the bit_buffer is full.

Benchmark results before:
```
hyperfine -m 100 --warmup 10 "./target/release/examples/compress 1 rs silesia-small.tar"
Benchmark 1: ./target/release/examples/compress 1 rs silesia-small.tar
  Time (mean ± σ):      92.2 ms ±   1.2 ms    [User: 79.9 ms, System: 12.3 ms]
  Range (min … max):    90.1 ms …  96.6 ms    100 runs
```
and with this change applied:
```
hyperfine -m 100 --warmup 10 "./target/release/examples/compress 1 rs silesia-small.tar"
Benchmark 1: ./target/release/examples/compress 1 rs silesia-small.tar
  Time (mean ± σ):      91.3 ms ±   0.9 ms    [User: 79.0 ms, System: 12.2 ms]
  Range (min … max):    89.7 ms …  95.2 ms    100 runs
```