### PR TITLE
Fix `inflate_fast_help` loop bound

### DIFF
--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -2028,9 +2028,7 @@ fn inflate_fast_help(state: &mut State, _start: usize) {
         }
 
         let remaining = bit_reader.bytes_remaining();
-        if remaining.saturating_sub(INFLATE_FAST_MIN_LEFT - 1) > 0
-            && writer.remaining() > INFLATE_FAST_MIN_LEFT
-        {
+        if remaining >= INFLATE_FAST_MIN_HAVE && writer.remaining() >= INFLATE_FAST_MIN_LEFT {
             continue;
         }
 

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -4,6 +4,7 @@
 use core::ffi::{c_char, c_int, c_long, c_ulong};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
+use core::ops::ControlFlow;
 
 mod bitreader;
 mod inffixed_tbl;
@@ -526,7 +527,7 @@ impl State<'_> {
     //
     // It unfortunately does duplicate the code for some of the states; deduplicating it by having
     // more of the states call this function is slower.
-    fn len_and_friends(&mut self) -> Option<ReturnCode> {
+    fn len_and_friends(&mut self) -> ControlFlow<ReturnCode, ()> {
         let avail_in = self.bit_reader.bytes_remaining();
         let avail_out = self.writer.remaining();
 
@@ -534,7 +535,7 @@ impl State<'_> {
             inflate_fast_help(self, 0);
             match self.mode {
                 Mode::Len => {}
-                _ => return None,
+                _ => return ControlFlow::Continue(()),
             }
         }
 
@@ -587,7 +588,7 @@ impl State<'_> {
                     if avail_in >= INFLATE_FAST_MIN_HAVE && avail_out >= INFLATE_FAST_MIN_LEFT {
                         restore!();
                         inflate_fast_help(self, 0);
-                        return None;
+                        return ControlFlow::Continue(());
                     }
 
                     self.back = 0;
@@ -604,7 +605,7 @@ impl State<'_> {
 
                         if let Err(return_code) = bit_reader.pull_byte() {
                             restore!();
-                            return Some(return_code);
+                            return ControlFlow::Break(return_code);
                         };
                     }
 
@@ -619,7 +620,7 @@ impl State<'_> {
 
                             if let Err(return_code) = bit_reader.pull_byte() {
                                 restore!();
-                                return Some(return_code);
+                                return ControlFlow::Break(return_code);
                             };
                         }
 
@@ -643,7 +644,7 @@ impl State<'_> {
                         mode = Mode::Type;
 
                         restore!();
-                        return None;
+                        return ControlFlow::Continue(());
                     } else if here.op & 64 != 0 {
                         mode = Mode::Bad;
                         {
@@ -653,7 +654,7 @@ impl State<'_> {
                             #[cfg(all(feature = "std", test))]
                             dbg!(msg);
                             this.error_message = Some(msg);
-                            return Some(this.inflate_leave(ReturnCode::DataError));
+                            return ControlFlow::Break(ReturnCode::DataError);
                         }
                     } else {
                         // length code
@@ -668,7 +669,7 @@ impl State<'_> {
                         restore!();
                         #[cfg(all(test, feature = "std"))]
                         eprintln!("Ok: writer is full ({} bytes)", self.writer.capacity());
-                        return Some(self.inflate_leave(ReturnCode::Ok));
+                        return ControlFlow::Break(ReturnCode::Ok);
                     }
 
                     writer.push(self.length as u8);
@@ -686,7 +687,7 @@ impl State<'_> {
                         match bit_reader.need_bits(extra) {
                             Err(return_code) => {
                                 restore!();
-                                return Some(self.inflate_leave(return_code));
+                                return ControlFlow::Break(return_code);
                             }
                             Ok(v) => v,
                         };
@@ -716,7 +717,7 @@ impl State<'_> {
 
                         if let Err(return_code) = bit_reader.pull_byte() {
                             restore!();
-                            return Some(return_code);
+                            return ControlFlow::Break(return_code);
                         };
                     }
 
@@ -733,7 +734,7 @@ impl State<'_> {
 
                             if let Err(return_code) = bit_reader.pull_byte() {
                                 restore!();
-                                return Some(return_code);
+                                return ControlFlow::Break(return_code);
                             };
                         }
 
@@ -746,7 +747,7 @@ impl State<'_> {
                     if here.op & 64 != 0 {
                         restore!();
                         self.mode = Mode::Bad;
-                        return Some(self.bad("invalid distance code\0"));
+                        return ControlFlow::Break(self.bad("invalid distance code\0"));
                     }
 
                     self.offset = here.val as usize;
@@ -764,7 +765,7 @@ impl State<'_> {
                         match bit_reader.need_bits(extra) {
                             Err(return_code) => {
                                 restore!();
-                                return Some(self.inflate_leave(return_code));
+                                return ControlFlow::Break(return_code);
                             }
                             Ok(v) => v,
                         };
@@ -776,7 +777,9 @@ impl State<'_> {
                     if INFLATE_STRICT && self.offset > self.dmax {
                         restore!();
                         self.mode = Mode::Bad;
-                        return Some(self.bad("invalid distance code too far back\0"));
+                        return ControlFlow::Break(
+                            self.bad("invalid distance code too far back\0"),
+                        );
                     }
 
                     // eprintln!("inflate: distance {}", state.offset);
@@ -794,7 +797,7 @@ impl State<'_> {
                             "BufError: writer is full ({} bytes)",
                             self.writer.capacity()
                         );
-                        return Some(self.inflate_leave(ReturnCode::Ok));
+                        return ControlFlow::Break(ReturnCode::Ok);
                     }
 
                     let left = writer.remaining();
@@ -809,7 +812,9 @@ impl State<'_> {
                             if self.flags.contains(Flags::SANE) {
                                 restore!();
                                 self.mode = Mode::Bad;
-                                return Some(self.bad("invalid distance too far back\0"));
+                                return ControlFlow::Break(
+                                    self.bad("invalid distance too far back\0"),
+                                );
                             }
 
                             // TODO INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
@@ -1398,8 +1403,8 @@ impl State<'_> {
                     continue 'label;
                 }
                 Mode::Len => match self.len_and_friends() {
-                    Some(return_code) => break 'label return_code,
-                    None => continue 'label,
+                    ControlFlow::Break(return_code) => break 'label return_code,
+                    ControlFlow::Continue(()) => continue 'label,
                 },
                 Mode::LenExt => {
                     // NOTE: this branch must be kept in sync with its counterpart in `len_and_friends`

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -532,7 +532,10 @@ impl State<'_> {
 
         if avail_in >= INFLATE_FAST_MIN_HAVE && avail_out >= INFLATE_FAST_MIN_LEFT {
             inflate_fast_help(self, 0);
-            return None;
+            match self.mode {
+                Mode::Len => {}
+                _ => return None,
+            }
         }
 
         let mut mode;
@@ -2027,7 +2030,8 @@ fn inflate_fast_help(state: &mut State, _start: usize) {
             break 'dolen;
         }
 
-        let remaining = bit_reader.bytes_remaining();
+        // include the bits in the bit_reader buffer in the count of available bytes
+        let remaining = bit_reader.bytes_remaining_including_buffer();
         if remaining >= INFLATE_FAST_MIN_HAVE && writer.remaining() >= INFLATE_FAST_MIN_LEFT {
             continue;
         }

--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -78,6 +78,11 @@ impl<'a> BitReader<'a> {
     }
 
     #[inline(always)]
+    pub fn bytes_remaining_including_buffer(&self) -> usize {
+        (self.end as usize - self.ptr as usize) + (self.bits_used as usize >> 3)
+    }
+
+    #[inline(always)]
     pub fn need_bits(&mut self, n: usize) -> Result<(), ReturnCode> {
         while (self.bits_used as usize) < n {
             self.pull_byte()?;


### PR DESCRIPTION
When you finally spot the thing... :facepalm: we are now faster than zlib-ng for all chunk sizes.

![chart (5)](https://github.com/user-attachments/assets/42011afb-6ab2-4747-b54e-068c4323d9f9)

It's only a marginal improvement for chunk size 2**4, but quite significant for what are probably the most common chunk sizes (very small chunk sizes likely indicate io-bound operation).

![chart (6)](https://github.com/user-attachments/assets/42c66b66-0180-457b-8deb-42bd5be4c6e3)

---

After fixing the bug of exiting the loop too early (first commit), I then made the bound a bit more accurate, and finally refactored the output type of `len_and_friends`. The final commit has no performance impact.