### PR TITLE
Hint to the compiler to inline the fill_window function

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1726,6 +1726,7 @@ pub(crate) const WANT_MIN_MATCH: usize = 4;
 
 pub(crate) const MIN_LOOKAHEAD: usize = STD_MAX_MATCH + STD_MIN_MATCH + 1;
 
+#[inline]
 pub(crate) fn fill_window(stream: &mut DeflateStream) {
     debug_assert!(stream.state.lookahead < MIN_LOOKAHEAD);
 


### PR DESCRIPTION
Inspired by @nmoinvaz suggestion in issue #18,  I went through the functions that currently aren't inlined and tried adding a compiler hint to inline them. Some didn't help or even caused regressions when inlined, but this one seems to improve performance at compression level 1:
```
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          73.6ms ± 3.79ms    71.6ms …  101ms          4 ( 6%)        0%
  peak_rss           26.7MB ± 76.8KB    26.5MB … 26.7MB          0 ( 0%)        0%
  cpu_cycles          281M  ± 14.9M      278M  …  402M           2 ( 3%)        0%
  instructions        568M  ±  265       568M  …  568M           0 ( 0%)        0%
  cache_references    265K  ± 2.95K      263K  …  285K           6 ( 9%)        0%
  cache_misses        232K  ± 9.17K      201K  …  245K          14 (21%)        0%
  branch_misses      2.94M  ± 6.20K     2.90M  … 2.95M           5 ( 7%)        0%
Benchmark 2 (70 runs): ./target/release/examples/blogpost-compress 1 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          71.5ms ±  710us    70.5ms … 74.1ms          2 ( 3%)        ⚡-  2.8% ±  1.2%
  peak_rss           26.7MB ± 80.1KB    26.5MB … 26.7MB          0 ( 0%)          -  0.1% ±  0.1%
  cpu_cycles          274M  ±  500K      273M  …  275M           0 ( 0%)        ⚡-  2.6% ±  1.2%
  instructions        565M  ±  277       565M  …  565M           1 ( 1%)          -  0.6% ±  0.0%
  cache_references    266K  ± 4.67K      263K  …  300K           2 ( 3%)          +  0.5% ±  0.5%
  cache_misses        231K  ± 9.01K      203K  …  245K          12 (17%)          -  0.0% ±  1.3%
  branch_misses      3.03M  ± 8.03K     3.01M  … 3.05M           0 ( 0%)        💩+  3.1% ±  0.1%
```

while not hurting performance at higher compression levels:
```
Benchmark 1 (12 runs): ./blogpost-compress-baseline 9 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           447ms ± 1.47ms     446ms …  451ms          1 ( 8%)        0%
  peak_rss           24.5MB ± 64.5KB    24.4MB … 24.5MB          0 ( 0%)        0%
  cpu_cycles         1.88G  ± 2.25M     1.88G  … 1.88G           5 (42%)        0%
  instructions       3.18G  ±  238      3.18G  … 3.18G           0 ( 0%)        0%
  cache_references    274K  ± 4.73K      269K  …  283K           0 ( 0%)        0%
  cache_misses        240K  ± 3.72K      229K  …  244K           2 (17%)        0%
  branch_misses      19.4M  ± 73.3K     19.3M  … 19.5M           0 ( 0%)        0%
Benchmark 2 (12 runs): ./target/release/examples/blogpost-compress 9 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           447ms ±  672us     445ms …  448ms          1 ( 8%)          -  0.0% ±  0.2%
  peak_rss           24.4MB ± 68.5KB    24.4MB … 24.5MB          0 ( 0%)          -  0.1% ±  0.2%
  cpu_cycles         1.88G  ± 1.63M     1.88G  … 1.88G           0 ( 0%)          +  0.1% ±  0.1%
  instructions       3.19G  ±  358      3.19G  … 3.19G           0 ( 0%)          +  0.2% ±  0.0%
  cache_references    274K  ± 4.74K      269K  …  285K           0 ( 0%)          +  0.1% ±  1.5%
  cache_misses        240K  ± 3.28K      231K  …  244K           1 ( 8%)          +  0.2% ±  1.2%
  branch_misses      19.3M  ± 37.7K     19.3M  … 19.4M           0 ( 0%)          -  0.4% ±  0.3%
```