### PR TITLE
Compare256 function pointer

### DIFF
--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -17,13 +17,13 @@ pub fn compare256_slice(src0: &[u8], src1: &[u8]) -> usize {
 #[inline(always)]
 fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
     #[cfg(target_feature = "avx2")]
-    return avx2::compare256(src0, src1);
+    return unsafe { avx2::compare256(src0, src1) };
 
     #[cfg(target_feature = "neon")]
-    return neon::compare256(src0, src1);
+    return unsafe { neon::compare256(src0, src1) };
 
     #[cfg(target_feature = "simd128")]
-    return wasm32::compare256(src0, src1);
+    return unsafe { wasm32::compare256(src0, src1) };
 
     #[allow(unreachable_code)]
     compare256_via_function_pointer(src0, src1)


### PR DESCRIPTION
when e.g. the avx2 target feature is not enabled at compile time, but the feature is available at runtime, this approach reduces branching. We still dispatch statically if the target feature is already enabled at compile time