### PR TITLE
Begin converting match offsets in struct State to u16

### DIFF
--- a/zlib-rs/src/deflate/algorithm/fast.rs
+++ b/zlib-rs/src/deflate/algorithm/fast.rs
@@ -53,7 +53,7 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
 
             // bflush = zng_tr_tally_dist(s, s->strstart - s->match_start, match_len - STD_MIN_MATCH);
             bflush = state.tally_dist(
-                state.strstart - state.match_start,
+                state.strstart - state.match_start as usize,
                 match_len - STD_MIN_MATCH,
             );
 

--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -80,7 +80,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
                     crate::deflate::longest_match::longest_match(state, hash_head);
                 state.match_start = match_start;
                 current_match.match_length = match_length as u16;
-                current_match.match_start = match_start as u16;
+                current_match.match_start = match_start;
                 if (current_match.match_length as usize) < WANT_MIN_MATCH {
                     current_match.match_length = 1;
                 }
@@ -123,7 +123,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
                     crate::deflate::longest_match::longest_match(state, hash_head);
                 state.match_start = match_start;
                 next_match.match_length = match_length as u16;
-                next_match.match_start = match_start as u16;
+                next_match.match_start = match_start;
 
                 if next_match.match_start >= next_match.strstart {
                     /* this can happen due to some restarts */

--- a/zlib-rs/src/deflate/algorithm/slow.rs
+++ b/zlib-rs/src/deflate/algorithm/slow.rs
@@ -49,7 +49,7 @@ pub fn deflate_slow(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
         };
 
         // Find the longest match, discarding those <= prev_length.
-        state.prev_match = state.match_start as u16;
+        state.prev_match = state.match_start;
         match_len = STD_MIN_MATCH - 1;
         dist = state.strstart as isize - hash_head as isize;
 


### PR DESCRIPTION
This is the first step of a refactoring to use smaller fields where possible in struct State for better cache locality.

This patch uses the `Pos` type from `longest_match.rs` to represent positions in the window.

My benchmark testing shows no change in performance compared to the current `main`.

