### PR TITLE
Rearrange fields in struct State for cache locality

### DIFF
--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -29,4 +29,5 @@ quickcheck = { workspace = true, optional = true }
 
 [dev-dependencies]
 crc32fast = "1.3.2"
+memoffset = "0.9.1"
 quickcheck.workspace = true

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1220,6 +1220,16 @@ pub(crate) struct State<'a> {
     /// is an active block and it is the last block.
     pub(crate) block_open: u8,
 
+    pub(crate) hash_calc_variant: HashCalcVariant,
+
+    pub(crate) match_available: bool, /* set if previous match exists */
+
+    pub(crate) strstart: usize,       /* start of string to insert */
+    pub(crate) w_mask: usize,          /* w_size - 1 */
+
+    pub(crate) match_start: Pos,      /* start of matching string */
+    pub(crate) prev_match: Pos,       /* previous match */
+
     bit_writer: BitWriter<'a>,
 
     /// Use a faster search when the previous match is longer than this
@@ -1227,15 +1237,6 @@ pub(crate) struct State<'a> {
 
     /// Stop searching when current match exceeds this
     pub(crate) nice_match: usize,
-
-    l_desc: TreeDesc<HEAP_SIZE>,             /* literal and length tree */
-    d_desc: TreeDesc<{ 2 * D_CODES + 1 }>,   /* distance tree */
-    bl_desc: TreeDesc<{ 2 * BL_CODES + 1 }>, /* Huffman tree for bit lengths */
-
-    pub(crate) strstart: usize,       /* start of string to insert */
-    pub(crate) match_start: Pos,      /* start of matching string */
-    pub(crate) prev_match: Pos,       /* previous match */
-    pub(crate) match_available: bool, /* set if previous match exists */
 
     /// Length of the best match at previous step. Matches not greater than this
     /// are discarded. This is used in the lazy match evaluation.
@@ -1299,7 +1300,6 @@ pub(crate) struct State<'a> {
 
     pub(crate) w_size: usize,    /* LZ77 window size (32K by default) */
     pub(crate) w_bits: usize,    /* log2(w_size)  (8..16) */
-    pub(crate) w_mask: usize,    /* w_size - 1 */
     pub(crate) lookahead: usize, /* number of valid bytes ahead in window */
 
     /// prev[N], where N is an offset in the current window, contains the offset in the window
@@ -1315,11 +1315,13 @@ pub(crate) struct State<'a> {
     ///  hash index of string to be inserted
     pub(crate) ins_h: usize,
 
-    pub(crate) hash_calc_variant: HashCalcVariant,
-
     crc_fold: crate::crc32::Crc32Fold,
     gzhead: Option<&'a mut gz_header>,
     gzindex: usize,
+
+    l_desc: TreeDesc<HEAP_SIZE>,             /* literal and length tree */
+    d_desc: TreeDesc<{ 2 * D_CODES + 1 }>,   /* distance tree */
+    bl_desc: TreeDesc<{ 2 * BL_CODES + 1 }>, /* Huffman tree for bit lengths */
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -4249,7 +4249,7 @@ mod test {
         }
     }
 
-    //#[cfg(target_arch = "x86_64")]
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn state_layout() {
         use memoffset::offset_of;

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -4249,7 +4249,7 @@ mod test {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[test]
     fn state_layout() {
         use memoffset::offset_of;


### PR DESCRIPTION
On my test system, this yields a small improvement in CPU cycles,
```
Benchmark 1 (68 runs): ./blogpost-compress-baseline-native 1 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          73.8ms ± 1.80ms    72.0ms … 86.1ms          1 ( 1%)        0%
  peak_rss           26.6MB ± 84.6KB    26.5MB … 26.7MB          0 ( 0%)        0%
  cpu_cycles          279M  ± 1.11M      278M  …  287M           2 ( 3%)        0%
  instructions        568M  ±  234       568M  …  568M           1 ( 1%)        0%
  cache_references    265K  ± 4.64K      262K  …  298K           7 (10%)        0%
  cache_misses        233K  ± 6.59K      207K  …  244K           6 ( 9%)        0%
  branch_misses      2.90M  ± 4.04K     2.89M  … 2.91M           1 ( 1%)        0%
Benchmark 2 (69 runs): ./target/release/examples/blogpost-compress 1 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          73.0ms ±  884us    71.4ms … 77.8ms          6 ( 9%)          -  1.0% ±  0.6%
  peak_rss           26.6MB ± 97.7KB    26.5MB … 26.7MB          0 ( 0%)          +  0.0% ±  0.1%
  cpu_cycles          277M  ± 1.76M      276M  …  290M           1 ( 1%)          -  0.9% ±  0.2%
  instructions        568M  ±  269       568M  …  568M           2 ( 3%)          +  0.0% ±  0.0%
  cache_references    265K  ± 5.08K      262K  …  303K           3 ( 4%)          -  0.0% ±  0.6%
  cache_misses        233K  ± 5.87K      210K  …  239K           6 ( 9%)          -  0.0% ±  0.9%
  branch_misses      2.88M  ± 4.12K     2.87M  … 2.89M           0 ( 0%)          -  0.7% ±  0.0%
```
