### PR TITLE
fuzzer: make sure the buffer is large enough to store the input

### DIFF
--- a/fuzz/fuzz_targets/compress.rs
+++ b/fuzz/fuzz_targets/compress.rs
@@ -22,7 +22,7 @@ fuzz_target!(|data: String| {
 
     deflated.truncate(length as usize);
 
-    let mut output = [0u8; 1 << 10];
+    let mut output = vec![0u8; data.len()];
     let config = zlib_rs::inflate::InflateConfig { window_bits: 15 };
     let (output, error) = zlib_rs::inflate::uncompress_slice(&mut output, &deflated, config);
     assert_eq!(ReturnCode::Ok, error);


### PR DESCRIPTION
fuzzers are broken on today's nightly, hopefully that will be fixed soon. 

But I ran into this problem on a local run, and it's a simple fix. I'll wait with merging till we can actually run these on CI though.