### PR TITLE
manual struct target feature

### DIFF
--- a/zlib-rs/src/cpu_features.rs
+++ b/zlib-rs/src/cpu_features.rs
@@ -1,6 +1,13 @@
 #![allow(dead_code)]
 #![allow(unreachable_code)]
 
+pub struct CpuFeatures;
+
+impl CpuFeatures {
+    pub const NONE: usize = 0;
+    pub const AVX2: usize = 1;
+}
+
 #[inline(always)]
 pub fn is_enabled_sse() -> bool {
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use core::mem::MaybeUninit;
 use core::ops::Range;
 
+use crate::cpu_features::CpuFeatures;
 use crate::weak_slice::WeakSliceMut;
 
 pub struct Writer<'a> {
@@ -77,6 +78,28 @@ impl<'a> Writer<'a> {
 
     #[inline(always)]
     pub fn extend_from_window(&mut self, window: &super::window::Window, range: Range<usize>) {
+        self.extend_from_window_with_features::<{ CpuFeatures::NONE }>(window, range)
+    }
+
+    pub fn extend_from_window_with_features<const FEATURES: usize>(
+        &mut self,
+        window: &super::window::Window,
+        range: Range<usize>,
+    ) {
+        match FEATURES {
+            #[cfg(target_arch = "x86_64")]
+            CpuFeatures::AVX2 => {
+                self.extend_from_window_help::<core::arch::x86_64::__m256i>(window, range)
+            }
+            _ => self.extend_from_window_runtime_dispatch(window, range),
+        }
+    }
+
+    fn extend_from_window_runtime_dispatch(
+        &mut self,
+        window: &super::window::Window,
+        range: Range<usize>,
+    ) {
         // NOTE: the dynamic check for avx512 makes avx2 slower. Measure this carefully before re-enabling
         //
         //        #[cfg(target_arch = "x86_64")]
@@ -140,6 +163,25 @@ impl<'a> Writer<'a> {
 
     #[inline(always)]
     pub fn copy_match(&mut self, offset_from_end: usize, length: usize) {
+        self.copy_match_with_features::<{ CpuFeatures::NONE }>(offset_from_end, length)
+    }
+
+    #[inline(always)]
+    pub fn copy_match_with_features<const FEATURES: usize>(
+        &mut self,
+        offset_from_end: usize,
+        length: usize,
+    ) {
+        match FEATURES {
+            #[cfg(target_arch = "x86_64")]
+            CpuFeatures::AVX2 => {
+                self.copy_match_help::<core::arch::x86_64::__m256i>(offset_from_end, length)
+            }
+            _ => self.copy_match_runtime_dispatch(offset_from_end, length),
+        }
+    }
+
+    fn copy_match_runtime_dispatch(&mut self, offset_from_end: usize, length: usize) {
         // NOTE: the dynamic check for avx512 makes avx2 slower. Measure this carefully before re-enabling
         //
         //        #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
this essentially inlines all avx2 codepaths.

this basically gives the same performance as `-Ctarget-cpu=native` on my machine.

but it's not the prettiest thing. I'm open to suggestions.