### PR TITLE
Micro-optimization for decompression

### DIFF
--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -120,7 +120,7 @@ impl<'a> BitReader<'a> {
         // SAFETY: assertion above ensures we have 8 bytes to read for a u64.
         let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) }.to_le();
         self.bit_buffer |= read << self.bits_used;
-        let increment = (63 - self.bits_used) >> 3;
+        let increment = (63 ^ self.bits_used) >> 3;
         self.ptr = self.ptr.wrapping_add(increment as usize);
         self.bits_used |= 56;
     }

--- a/zlib-rs/src/inflate/bitreader.rs
+++ b/zlib-rs/src/inflate/bitreader.rs
@@ -120,6 +120,8 @@ impl<'a> BitReader<'a> {
         // SAFETY: assertion above ensures we have 8 bytes to read for a u64.
         let read = unsafe { core::ptr::read_unaligned(self.ptr.cast::<u64>()) }.to_le();
         self.bit_buffer |= read << self.bits_used;
+        // this xor was previously a subtraction but was changed for performance reasons.
+        // for bits_used between 0 and 63 (inclusive), it will always have the same behavior.
         let increment = (63 ^ self.bits_used) >> 3;
         self.ptr = self.ptr.wrapping_add(increment as usize);
         self.bits_used |= 56;


### PR DESCRIPTION
The BitReader::refill function flips the last 6 bits by subtracting a number from 63, but in this case it's actually faster to do it with xor.

asm before (assuming it's not inlined):
```asm
mov rax, qword ptr [rdi]
mov rdx, qword ptr [rax]
movzx ecx, byte ptr [rdi + 24]
shl rdx, cl
or qword ptr [rdi + 16], rdx
mov dl, 63
sub dl, cl
shr dl, 3
movzx edx, dl
add rdx, rax
mov qword ptr [rdi], rdx
or cl, 56
mov byte ptr [rdi + 24], cl
ret
```
asm after:
```asm
mov rax, qword ptr [rdi]
mov rdx, qword ptr [rax]
movzx ecx, byte ptr [rdi + 24]
shl rdx, cl
or qword ptr [rdi + 16], rdx
mov edx, ecx
shr edx, 3
xor rdx, 7
add rdx, rax
mov qword ptr [rdi], rdx
or cl, 56
mov byte ptr [rdi + 24], cl
ret
```

Usually this change wouldn't matter, but because we extend the `increment` into a usize after, the compiler was adding an unnecessary `movzx`. However if we use xor, then the compiler is smart enough to realize that there's no need to zero-extend.

In my benchmarks, this change makes inflate about 1-2% faster (and according to Callgrind it uses 0.9% less instructions).

