### PR TITLE
fix alignment in zeroed allocations

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -397,22 +397,34 @@ jobs:
   miri:
     name: "Miri"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-pc-windows-gnu
     steps:
       - uses: actions/checkout@v3
       - name: Install Miri
         run: |
+          rustup target add ${{ matrix.target }}
           rustup toolchain install nightly --component miri
           cargo +nightly miri setup
+      - name: Install gcc
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        with:
+          packages: gcc-mingw-w64-x86-64
+          version: 1.0
+        if: ${{ contains(matrix.target, 'windows') }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@56ab7930c591507f833cbaed864d201386d518a8
         with:
           tool: cargo-nextest
       - name: Test public C api with NULL arguments
-        run: "cargo +nightly miri nextest run -j4 -p test-libz-rs-sys null::"
+        run: "cargo +nightly miri nextest run -j4 -p test-libz-rs-sys --target ${{ matrix.target }} null::"
         env:
           RUSTFLAGS: "-Ctarget-feature=+avx2"
       - name: Test allocator with miri
-        run: "cargo +nightly miri nextest run -j4 -p zlib-rs allocate::"
+        run: "cargo +nightly miri nextest run -j4 -p zlib-rs --target ${{ matrix.target }} allocate::"
 
   run-flate2-test-suite:
     name: run flate2 test suite


### PR DESCRIPTION
Using an incorrect alignment is UB (on some platforms, e.g. miri caught it on windows, but not on linux)