### PR TITLE
run the uncompress fuzzer with a custom corpus and gather fuzzer codecov

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -254,6 +254,61 @@ jobs:
             RUST_BACKTRACE=1 cargo fuzz run --no-default-features --features="$features" $target -- -max_total_time=10
           done
 
+  fuzz-code-coverage:
+    name: Fuzz with code coverage 
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - fuzz_target: uncompress2
+            corpus: "gzip-files/compressed"
+            features: '--no-default-features --features="disable-checksum"'
+            flags: fuzz-decompress
+          - fuzz_target: compress
+            corpus: ""
+            features: ''
+            flags: fuzz-compress
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+      - name: Install cargo fuzz & rustfilt
+        uses: taiki-e/install-action@56ab7930c591507f833cbaed864d201386d518a8
+        with:
+          tool: cargo-fuzz,rustfilt
+      - name: Download custom decompression corpus
+        if: ${{ contains(matrix.corpus, 'gzip-files') }}
+        run: |
+          wget https://github.com/trifectatechfoundation/compression-corpus/releases/download/2025-04-14-103007/gzip-files.zip
+          unzip gzip-files.zip -d gzip-files
+      - name: Run `cargo fuzz`
+        env:
+          RUST_BACKTRACE: "1"
+        run: |
+          cargo fuzz run ${{matrix.features}} ${{matrix.fuzz_target}} ${{matrix.corpus}} -- -max_total_time=10
+      - name: Fuzz codecov
+        run: |
+          cargo fuzz coverage ${{matrix.features}} ${{matrix.fuzz_target}} ${{matrix.corpus}}
+          $(rustc --print sysroot)/lib/rustlib/$(rustc --print host-tuple)/bin/llvm-cov export -Xdemangler=rustfilt \
+              target/$(rustc --print host-tuple)/coverage/$(rustc --print host-tuple)/release/${{matrix.fuzz_target}} \
+              -instr-profile=fuzz/coverage/${{matrix.fuzz_target}}/coverage.profdata \
+              --format=lcov \
+              -ignore-filename-regex="\.cargo|\.rustup" > lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+        with:
+          files: ./lcov.info
+          fail_ci_if_error: false
+          flags: ${{ matrix.flags }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: fuzz
+
   link-c-dynamic-library:
     name: vanilla dynamic library
     strategy:


### PR DESCRIPTION
The corpus for decompression is generated by https://github.com/folkertdev/compression-corpus/blob/main/.github/workflows/generate.yml, to cover all of the compression levels, plus some extra things. It does pretty well given that it only runs for a limited time.

We could store the corpus zip in the repo, right now it's downloaded by the action. 