### PR TITLE
Copy chunks as `MaybeUninit<u8>`

### DIFF
--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -1382,6 +1382,46 @@ fn gzip_header_fields_insufficient_space() {
 }
 
 #[test]
+fn inflate_with_uninitialized_output_buffer() {
+    let input = include_bytes!("test-data/issue-109.gz");
+
+    let config = InflateConfig::default();
+
+    assert_eq_rs_ng!({
+        let mut stream = MaybeUninit::<z_stream>::zeroed();
+
+        const VERSION: *const c_char = libz_rs_sys::zlibVersion();
+        const STREAM_SIZE: c_int = core::mem::size_of::<z_stream>() as c_int;
+
+        let err = unsafe {
+            inflateInit2_(
+                stream.as_mut_ptr(),
+                16 + config.window_bits,
+                VERSION,
+                STREAM_SIZE,
+            )
+        };
+        assert_eq!(err, 0);
+
+        let stream = unsafe { stream.assume_init_mut() };
+
+        let mut output = [MaybeUninit::<u8>::uninit(); 256];
+        stream.next_out = output.as_mut_ptr().cast();
+        stream.avail_out = output.len() as _;
+
+        let chunk = &input[..128];
+        stream.next_in = chunk.as_ptr().cast_mut();
+        stream.avail_in = chunk.len() as _;
+
+        let err = unsafe { inflate(stream, InflateFlush::NoFlush as _) };
+        assert_eq!(err, ReturnCode::Ok as i32);
+
+        let err = unsafe { inflateEnd(stream) };
+        assert_eq!(err, ReturnCode::Ok as i32);
+    });
+}
+
+#[test]
 fn gzip_chunked_1_byte() {
     gzip_chunked(1);
 }

--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -1382,46 +1382,6 @@ fn gzip_header_fields_insufficient_space() {
 }
 
 #[test]
-fn inflate_with_uninitialized_output_buffer() {
-    let input = include_bytes!("test-data/issue-109.gz");
-
-    let config = InflateConfig::default();
-
-    assert_eq_rs_ng!({
-        let mut stream = MaybeUninit::<z_stream>::zeroed();
-
-        const VERSION: *const c_char = libz_rs_sys::zlibVersion();
-        const STREAM_SIZE: c_int = core::mem::size_of::<z_stream>() as c_int;
-
-        let err = unsafe {
-            inflateInit2_(
-                stream.as_mut_ptr(),
-                16 + config.window_bits,
-                VERSION,
-                STREAM_SIZE,
-            )
-        };
-        assert_eq!(err, 0);
-
-        let stream = unsafe { stream.assume_init_mut() };
-
-        let mut output = [MaybeUninit::<u8>::uninit(); 256];
-        stream.next_out = output.as_mut_ptr().cast();
-        stream.avail_out = output.len() as _;
-
-        let chunk = &input[..128];
-        stream.next_in = chunk.as_ptr().cast_mut();
-        stream.avail_in = chunk.len() as _;
-
-        let err = unsafe { inflate(stream, InflateFlush::NoFlush as _) };
-        assert_eq!(err, ReturnCode::Ok as i32);
-
-        let err = unsafe { inflateEnd(stream) };
-        assert_eq!(err, ReturnCode::Ok as i32);
-    });
-}
-
-#[test]
 fn gzip_chunked_1_byte() {
     gzip_chunked(1);
 }

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -295,15 +295,15 @@ impl<'a> Writer<'a> {
 ///
 /// Must be valid to read a `[u8; N]` value from `from` with an unaligned read.
 #[inline(always)]
-unsafe fn load_chunk<const N: usize>(from: *const MaybeUninit<u8>) -> [u8; N] {
-    core::ptr::read_unaligned(from.cast::<[u8; N]>())
+unsafe fn load_chunk<const N: usize>(from: *const MaybeUninit<u8>) -> [MaybeUninit<u8>; N] {
+    core::ptr::read_unaligned(from.cast::<[MaybeUninit<u8>; N]>())
 }
 
 /// # Safety
 ///
 /// Must be valid to write a `[u8; N]` value to `out` with an unaligned write.
 #[inline(always)]
-unsafe fn store_chunk<const N: usize>(out: *mut MaybeUninit<u8>, chunk: [u8; N]) {
+unsafe fn store_chunk<const N: usize>(out: *mut MaybeUninit<u8>, chunk: [MaybeUninit<u8>; N]) {
     core::ptr::write_unaligned(out.cast(), chunk)
 }
 


### PR DESCRIPTION
When the output buffer contained uninitialized memory, MIRI reported an error in the `copy_chunk_unchecked` function. That is unsound, though I don't see any way that could have been observed or exploited.

The bounds checks are all valid as far as I can see, so I think it's OK to just read/write the memory without assuming that it is initialized. Let's see if this has a performance impact though.