### PR TITLE
check for and enable the `bmi1` and `bmi2` target feature

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -479,7 +479,7 @@ jobs:
       - name: Test public C api with NULL arguments
         run: "cargo +nightly miri nextest run -j4 -p test-libz-rs-sys --target ${{ matrix.target }} null::"
         env:
-          RUSTFLAGS: "-Ctarget-feature=+avx2,+bmi2"
+          RUSTFLAGS: "-Ctarget-feature=+avx2,+bmi2,+bmi1"
       - name: Test allocator with miri
         run: "cargo +nightly miri nextest run -j4 -p zlib-rs --target ${{ matrix.target }} allocate::"
       - name: Test gz logic with miri

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -479,7 +479,7 @@ jobs:
       - name: Test public C api with NULL arguments
         run: "cargo +nightly miri nextest run -j4 -p test-libz-rs-sys --target ${{ matrix.target }} null::"
         env:
-          RUSTFLAGS: "-Ctarget-feature=+avx2"
+          RUSTFLAGS: "-Ctarget-feature=+avx2,+bmi2"
       - name: Test allocator with miri
         run: "cargo +nightly miri nextest run -j4 -p zlib-rs --target ${{ matrix.target }} allocate::"
       - name: Test gz logic with miri

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -10,7 +10,7 @@ mod wasm;
 
 pub fn adler32(start_checksum: u32, data: &[u8]) -> u32 {
     #[cfg(target_arch = "x86_64")]
-    if crate::cpu_features::is_enabled_avx2() {
+    if crate::cpu_features::is_enabled_avx2_and_bmi2() {
         return avx2::adler32_avx2(start_checksum, data);
     }
 

--- a/zlib-rs/src/adler32/avx2.rs
+++ b/zlib-rs/src/adler32/avx2.rs
@@ -63,12 +63,13 @@ unsafe fn partial_hsum256(x: __m256i) -> u32 {
 }
 
 pub fn adler32_avx2(adler: u32, src: &[u8]) -> u32 {
-    assert!(crate::cpu_features::is_enabled_avx2());
+    assert!(crate::cpu_features::is_enabled_avx2_and_bmi2());
     // SAFETY: the assertion above ensures this code is not executed unless the CPU has AVX2.
     unsafe { adler32_avx2_help(adler, src) }
 }
 
 #[target_feature(enable = "avx2")]
+#[target_feature(enable = "bmi2")]
 unsafe fn adler32_avx2_help(adler: u32, src: &[u8]) -> u32 {
     if src.is_empty() {
         return adler;

--- a/zlib-rs/src/adler32/avx2.rs
+++ b/zlib-rs/src/adler32/avx2.rs
@@ -70,6 +70,7 @@ pub fn adler32_avx2(adler: u32, src: &[u8]) -> u32 {
 
 #[target_feature(enable = "avx2")]
 #[target_feature(enable = "bmi2")]
+#[target_feature(enable = "bmi1")]
 unsafe fn adler32_avx2_help(adler: u32, src: &[u8]) -> u32 {
     if src.is_empty() {
         return adler;

--- a/zlib-rs/src/cpu_features.rs
+++ b/zlib-rs/src/cpu_features.rs
@@ -29,23 +29,32 @@ pub fn is_enabled_sse42() -> bool {
 #[inline(always)]
 pub fn is_enabled_avx2_and_bmi2() -> bool {
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    #[cfg(feature = "std")]
     {
-        use std::sync::atomic::{AtomicU32, Ordering};
+        #[cfg(all(
+            target_feature = "avx2",
+            target_feature = "bmi1",
+            target_feature = "bmi2"
+        ))]
+        return true;
 
-        static CACHE: AtomicU32 = AtomicU32::new(2);
+        #[cfg(feature = "std")]
+        {
+            use std::sync::atomic::{AtomicU32, Ordering};
 
-        return match CACHE.load(Ordering::Relaxed) {
-            0 => false,
-            1 => true,
-            _ => {
-                let detected = std::is_x86_feature_detected!("avx2")
-                    && std::is_x86_feature_detected!("bmi1")
-                    && std::is_x86_feature_detected!("bmi2");
-                CACHE.store(u32::from(detected), Ordering::Relaxed);
-                detected
-            }
-        };
+            static CACHE: AtomicU32 = AtomicU32::new(2);
+
+            return match CACHE.load(Ordering::Relaxed) {
+                0 => false,
+                1 => true,
+                _ => {
+                    let detected = std::is_x86_feature_detected!("avx2")
+                        && std::is_x86_feature_detected!("bmi1")
+                        && std::is_x86_feature_detected!("bmi2");
+                    CACHE.store(u32::from(detected), Ordering::Relaxed);
+                    detected
+                }
+            };
+        }
     }
 
     false

--- a/zlib-rs/src/cpu_features.rs
+++ b/zlib-rs/src/cpu_features.rs
@@ -39,8 +39,9 @@ pub fn is_enabled_avx2_and_bmi2() -> bool {
             0 => false,
             1 => true,
             _ => {
-                let detected =
-                    std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("bmi2");
+                let detected = std::is_x86_feature_detected!("avx2")
+                    && std::is_x86_feature_detected!("bmi1")
+                    && std::is_x86_feature_detected!("bmi2");
                 CACHE.store(u32::from(detected), Ordering::Relaxed);
                 detected
             }

--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -181,6 +181,7 @@ mod avx2 {
     /// Behavior is undefined if the `avx` target feature is not enabled
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "bmi2")]
+    #[target_feature(enable = "bmi1")]
     pub unsafe fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
         let src0 = src0.chunks_exact(32);
         let src1 = src1.chunks_exact(32);

--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -10,7 +10,7 @@ pub fn compare256_slice(src0: &[u8], src1: &[u8]) -> usize {
 
 fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
     #[cfg(target_arch = "x86_64")]
-    if crate::cpu_features::is_enabled_avx2() {
+    if crate::cpu_features::is_enabled_avx2_and_bmi2() {
         return unsafe { avx2::compare256(src0, src1) };
     }
 
@@ -180,6 +180,7 @@ mod avx2 {
     ///
     /// Behavior is undefined if the `avx` target feature is not enabled
     #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "bmi2")]
     pub unsafe fn compare256(src0: &[u8; 256], src1: &[u8; 256]) -> usize {
         let src0 = src0.chunks_exact(32);
         let src1 = src1.chunks_exact(32);
@@ -212,7 +213,7 @@ mod avx2 {
 
     #[test]
     fn test_compare256() {
-        if crate::cpu_features::is_enabled_avx2() {
+        if crate::cpu_features::is_enabled_avx2_and_bmi2() {
             let str1 = [b'a'; super::MAX_COMPARE_SIZE];
             let mut str2 = [b'a'; super::MAX_COMPARE_SIZE];
 

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -55,6 +55,7 @@ mod avx2 {
     /// Behavior is undefined if the `avx2` target feature is not enabled
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "bmi2")]
+    #[target_feature(enable = "bmi1")]
     pub unsafe fn slide_hash_chain(table: &mut [u16], wsize: u16) {
         // 64 means that 4 256-bit values can be processed per iteration.
         // That appear to be the optimal amount for avx2.

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -10,8 +10,8 @@ pub fn slide_hash(state: &mut crate::deflate::State) {
 
 fn slide_hash_chain(table: &mut [u16], wsize: u16) {
     #[cfg(target_arch = "x86_64")]
-    if crate::cpu_features::is_enabled_avx2() {
-        // SAFETY: the avx2 target feature is enabled.
+    if crate::cpu_features::is_enabled_avx2_and_bmi2() {
+        // SAFETY: the avx2 and bmi2 target feature are enabled.
         return unsafe { avx2::slide_hash_chain(table, wsize) };
     }
 
@@ -54,6 +54,7 @@ mod avx2 {
     ///
     /// Behavior is undefined if the `avx2` target feature is not enabled
     #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "bmi2")]
     pub unsafe fn slide_hash_chain(table: &mut [u16], wsize: u16) {
         // 64 means that 4 256-bit values can be processed per iteration.
         // That appear to be the optimal amount for avx2.
@@ -155,7 +156,7 @@ mod tests {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_slide_hash_avx2() {
-        if crate::cpu_features::is_enabled_avx2() {
+        if crate::cpu_features::is_enabled_avx2_and_bmi2() {
             let mut input = INPUT;
 
             unsafe { avx2::slide_hash_chain(&mut input, WSIZE) };

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1827,6 +1827,7 @@ fn inflate_fast_help(state: &mut State, start: usize) {
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx2")]
 #[target_feature(enable = "bmi2")]
+#[target_feature(enable = "bmi1")]
 unsafe fn inflate_fast_help_avx2(state: &mut State, start: usize) {
     inflate_fast_help_impl::<{ CpuFeatures::AVX2 }>(state, start);
 }

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -1816,7 +1816,7 @@ impl State<'_> {
 
 fn inflate_fast_help(state: &mut State, start: usize) {
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    if crate::cpu_features::is_enabled_avx2() {
+    if crate::cpu_features::is_enabled_avx2_and_bmi2() {
         // SAFETY: we've verified the target features
         return unsafe { inflate_fast_help_avx2(state, start) };
     }
@@ -1826,6 +1826,7 @@ fn inflate_fast_help(state: &mut State, start: usize) {
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx2")]
+#[target_feature(enable = "bmi2")]
 unsafe fn inflate_fast_help_avx2(state: &mut State, start: usize) {
     inflate_fast_help_impl::<{ CpuFeatures::AVX2 }>(state, start);
 }

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -106,7 +106,7 @@ impl<'a> Writer<'a> {
         //        }
 
         #[cfg(target_arch = "x86_64")]
-        if crate::cpu_features::is_enabled_avx2() {
+        if crate::cpu_features::is_enabled_avx2_and_bmi2() {
             return self.extend_from_window_help::<32>(window, range);
         }
 
@@ -186,7 +186,7 @@ impl<'a> Writer<'a> {
         //        }
 
         #[cfg(target_arch = "x86_64")]
-        if crate::cpu_features::is_enabled_avx2() {
+        if crate::cpu_features::is_enabled_avx2_and_bmi2() {
             return self.copy_match_help::<32>(offset_from_end, length);
         }
 
@@ -379,7 +379,7 @@ mod test {
         }
 
         #[cfg(target_arch = "x86_64")]
-        if crate::cpu_features::is_enabled_avx2() {
+        if crate::cpu_features::is_enabled_avx2_and_bmi2() {
             helper!(Writer::copy_match_help::<32>);
         }
 


### PR DESCRIPTION
closes #361 

Locally this is very effective, CI shows a lot more noise. But it does make sense that this would be faster right?

```
Benchmark 2 (73 runs): target/release/examples/blogpost-uncompress rs-chunked 4 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          68.9ms ±  522us    68.3ms … 70.7ms          2 ( 3%)          -  1.2% ±  0.3%
  peak_rss           24.1MB ± 75.4KB    23.9MB … 24.1MB          0 ( 0%)          -  0.1% ±  0.1%
  cpu_cycles          270M  ± 1.59M      268M  …  278M           4 ( 5%)        ⚡-  1.5% ±  0.2%
  instructions        781M  ±  400       781M  …  781M           2 ( 3%)          -  0.1% ±  0.0%
  cache_references   3.14M  ± 97.1K     2.85M  … 3.36M           0 ( 0%)          -  2.1% ±  1.1%
  cache_misses       83.8K  ± 14.4K     51.4K  …  129K           1 ( 1%)        💩+  7.0% ±  5.4%
  branch_misses      4.09M  ± 11.0K     4.08M  … 4.12M           0 ( 0%)          +  0.2% ±  0.1%
Benchmark 2 (152 runs): target/release/examples/blogpost-uncompress rs-chunked 12 silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.9ms ±  842us    32.3ms … 41.8ms         10 ( 7%)        ⚡-  2.8% ±  0.5%
  peak_rss           24.1MB ± 58.4KB    24.0MB … 24.1MB          0 ( 0%)          +  0.0% ±  0.1%
  cpu_cycles          111M  ± 2.73M      110M  …  141M          13 ( 9%)        ⚡-  3.7% ±  0.4%
  instructions        265M  ±  276       265M  …  265M           0 ( 0%)        ⚡-  6.4% ±  0.0%
  cache_references   3.38M  ±  153K     3.13M  … 4.62M           5 ( 3%)        ⚡-  2.3% ±  0.9%
  cache_misses       40.3K  ± 12.2K     30.6K  …  167K          10 ( 7%)        💩+  8.7% ±  6.0%
  branch_misses      1.79M  ± 1.95K     1.79M  … 1.81M           8 ( 5%)          -  0.1% ±  0.0%
Benchmark 2 (62 runs): target/release/examples/blogpost-compress 1 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          81.8ms ±  950us    80.1ms … 86.5ms          3 ( 5%)          -  0.1% ±  0.4%
  peak_rss           26.7MB ± 68.6KB    26.5MB … 26.7MB          0 ( 0%)          -  0.0% ±  0.1%
  cpu_cycles          288M  ± 2.76M      284M  …  303M           1 ( 2%)          +  0.3% ±  0.3%
  instructions        582M  ±  296       582M  …  582M           0 ( 0%)          -  1.0% ±  0.0%
  cache_references   19.9M  ±  211K     19.4M  … 20.5M           5 ( 8%)          +  0.0% ±  0.3%
  cache_misses        407K  ± 83.5K      293K  …  644K           5 ( 8%)        ⚡-  9.6% ±  5.7%
  branch_misses      2.97M  ± 2.46K     2.97M  … 2.98M           1 ( 2%)          +  0.2% ±  0.0%
Benchmark 2 (12 runs): target/release/examples/blogpost-compress 9 rs silesia-small.tar
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           429ms ± 2.82ms     426ms …  434ms          0 ( 0%)        ⚡-  2.5% ±  0.8%
  peak_rss           24.4MB ±  102KB    24.2MB … 24.5MB          0 ( 0%)          +  0.0% ±  0.3%
  cpu_cycles         1.84G  ± 9.16M     1.83G  … 1.86G           2 (17%)        ⚡-  2.5% ±  0.8%
  instructions       3.43G  ±  270      3.43G  … 3.43G           0 ( 0%)          -  0.6% ±  0.0%
  cache_references    197M  ±  759K      196M  …  198M           0 ( 0%)          -  0.9% ±  0.8%
  cache_misses       2.36M  ±  438K     1.69M  … 3.00M           0 ( 0%)          - 34.7% ± 40.4%
  branch_misses      15.8M  ± 41.1K     15.7M  … 15.8M           0 ( 0%)          +  0.1% ±  0.2%
```