### PR TITLE
Hard-code the hash selection for the fast and medium deflate algorithms

### DIFF
--- a/zlib-rs/src/deflate/algorithm/fast.rs
+++ b/zlib-rs/src/deflate/algorithm/fast.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use crate::deflate::hash_calc::StandardHashCalc;
 use crate::{
     deflate::{
         fill_window, BlockState, DeflateStream, MIN_LOOKAHEAD, STD_MIN_MATCH, WANT_MIN_MATCH,
@@ -33,7 +34,7 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
         // dictionary, and set hash_head to the head of the hash chain:
 
         if state.lookahead >= WANT_MIN_MATCH {
-            let hash_head = state.quick_insert_string(state.strstart);
+            let hash_head = StandardHashCalc::quick_insert_string(state, state.strstart);
             dist = state.strstart as isize - hash_head as isize;
 
             /* Find the longest match, discarding those <= prev_length.
@@ -70,7 +71,7 @@ pub fn deflate_fast(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockSta
                 state.strstart += match_len;
             } else {
                 state.strstart += match_len;
-                state.quick_insert_string(state.strstart + 2 - STD_MIN_MATCH);
+                StandardHashCalc::quick_insert_string(state, state.strstart + 2 - STD_MIN_MATCH);
 
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use crate::deflate::hash_calc::StandardHashCalc;
 use crate::{
     deflate::{
         fill_window, BlockState, DeflateStream, State, MIN_LOOKAHEAD, STD_MIN_MATCH, WANT_MIN_MATCH,
@@ -60,7 +61,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
         } else {
             hash_head = 0;
             if state.lookahead >= WANT_MIN_MATCH {
-                hash_head = state.quick_insert_string(state.strstart);
+                hash_head = StandardHashCalc::quick_insert_string(state, state.strstart);
             }
 
             current_match.strstart = state.strstart as u16;
@@ -104,7 +105,7 @@ pub fn deflate_medium(stream: &mut DeflateStream, flush: DeflateFlush) -> BlockS
                 < (state.window_size - MIN_LOOKAHEAD)
         {
             state.strstart = (current_match.strstart + current_match.match_length) as usize;
-            hash_head = state.quick_insert_string(state.strstart);
+            hash_head = StandardHashCalc::quick_insert_string(state, state.strstart);
 
             next_match.strstart = state.strstart as u16;
             next_match.orgstart = next_match.strstart;
@@ -253,7 +254,7 @@ fn insert_match(state: &mut State, mut m: Match) {
         m.match_length = 0;
 
         if (m.strstart as usize) >= (STD_MIN_MATCH - 2) {
-            state.quick_insert_string(m.strstart as usize + 2 - STD_MIN_MATCH);
+            StandardHashCalc::quick_insert_string(state, m.strstart as usize + 2 - STD_MIN_MATCH);
         }
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not


### PR DESCRIPTION
Note: This only changes the quick_insert_string calls. In testing, bypassing the hash_calc_variant check on the insert_string calls in these algorithms appears to (counterintuitively) hurt performance.