### PR TITLE
Fix import resolution in crc32 for the Android build

### DIFF
--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -90,7 +90,7 @@ impl Crc32Fold {
 
 #[cfg(test)]
 mod test {
-    use test::braid::crc32_braid;
+    use braid::crc32_braid;
 
     use super::*;
 


### PR DESCRIPTION
I see the following error when attempting to build zlib-rs tests in the Android project, although not when building with Cargo (not sure why):

error: cannot determine resolution for the import
  --> external/rust/android-crates-io/crates/zlib-rs/src/crc32.rs:93:9
   |
93 |     use test::braid::crc32_braid;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^

error[E0659]: `test` is ambiguous
  --> external/rust/android-crates-io/crates/zlib-rs/src/crc32.rs:93:9
   |
93 |     use test::braid::crc32_braid;
   |         ^^^^ ambiguous name
   |
   = note: ambiguous because of a conflict between a name from a glob import and
 an outer scope during import or macro resolution
   = note: `test` could refer to a crate passed with `--extern`
   = help: use `::test` to refer to this crate unambiguously
note: `test` could also refer to the module imported here
  --> external/rust/android-crates-io/crates/zlib-rs/src/crc32.rs:95:9
   |
95 |     use super::*;
   |         ^^^^^^^^
   = help: consider adding an explicit import of `test` to disambiguate
   = help: or use `self::test` to refer to this module unambiguously

Removing "test::" fixes it. Tests continue to pass both using cargo and the Android build system.