### PR TITLE
fix a bug in the value of the FTEXT field of the gz header

### DIFF
--- a/test-libz-rs-sys/src/deflate.rs
+++ b/test-libz-rs-sys/src/deflate.rs
@@ -672,9 +672,9 @@ fn deflate_bound_gzip_header_help(
 }
 
 #[test]
-fn gz_header_text_check() {
+fn gz_header_text_and_hcrc_check() {
     // when constructing the gz header flags, zlib-rs performed a check
-    // for `text > 0` that should have been `text != 0`.
+    // for `text > 0` that should have been `text != 0`, similarly for hcrc.
     let config = DeflateConfig {
         level: 9,
         method: Method::Deflated,
@@ -703,14 +703,14 @@ fn gz_header_text_check() {
         let strm = strm.assume_init_mut();
 
         let mut header = gz_header {
-            text: -16777216,
-            time: 4278223747,
+            text: -42,
+            time: 0,
             os: 0,
             extra: core::ptr::null_mut(),
             extra_len: 0,
             name: [0u8].as_mut_ptr(),
             comment: [0u8].as_mut_ptr(),
-            hcrc: 0,
+            hcrc: -42,
             //
             xflags: 0,
             extra_max: 0,

--- a/zlib-rs/src/c_api.rs
+++ b/zlib-rs/src/c_api.rs
@@ -253,7 +253,7 @@ impl gz_header {
 
     pub(crate) fn flags(&self) -> u8 {
         (if self.text != 0 { 1 } else { 0 })
-            + (if self.hcrc > 0 { 2 } else { 0 })
+            + (if self.hcrc != 0 { 2 } else { 0 })
             + (if self.extra.is_null() { 0 } else { 4 })
             + (if self.name.is_null() { 0 } else { 8 })
             + (if self.comment.is_null() { 0 } else { 16 })

--- a/zlib-rs/src/c_api.rs
+++ b/zlib-rs/src/c_api.rs
@@ -252,7 +252,7 @@ impl gz_header {
     };
 
     pub(crate) fn flags(&self) -> u8 {
-        (if self.text > 0 { 1 } else { 0 })
+        (if self.text != 0 { 1 } else { 0 })
             + (if self.hcrc > 0 { 2 } else { 0 })
             + (if self.extra.is_null() { 0 } else { 4 })
             + (if self.name.is_null() { 0 } else { 8 })

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -2603,7 +2603,7 @@ pub fn deflate(stream: &mut DeflateStream, flush: DeflateFlush) -> ReturnCode {
                     stream.state.bit_writer.pending.extend(&bytes);
                 }
 
-                if gzhead.hcrc > 0 {
+                if gzhead.hcrc != 0 {
                     stream.adler = crc32(
                         stream.adler as u32,
                         stream.state.bit_writer.pending.pending(),


### PR DESCRIPTION
this field is used as a hint, to indicate that the file is probably ASCII text. We checked for `> 0`, but should be checking for `!= 0` for consistency with zlib-ng.

See https://github.com/zlib-ng/zlib-ng/blob/2c98ece180e1b541f0311220e38937dd0a94d08e/deflate.c#L923.