### PR TITLE
Use core::mem::transmute instead of std in wasm adler32

### DIFF
--- a/zlib-rs/src/adler32/wasm.rs
+++ b/zlib-rs/src/adler32/wasm.rs
@@ -137,7 +137,7 @@ fn u32x4_extadd_quarters_u8x16(a: v128) -> v128 {
 
 #[inline(always)]
 fn reduce_add(v: v128) -> u32 {
-    let arr: [u32; 4] = unsafe { std::mem::transmute(v) };
+    let arr: [u32; 4] = unsafe { core::mem::transmute(v) };
     let mut sum = 0u32;
     for val in arr {
         sum = sum.wrapping_add(val);


### PR DESCRIPTION
When compiling zlib_rs for wasm32-unknown-unknown with `default-features = false`, the build fails because `zlib-rs/src/adler32/wasm.rs` uses std::mem::transmute. This PR uses core::mem::transmute instead, since it does the same job and doesn't break `no_std` builds.