### PR TITLE
expose the 64-bit versions of some gz functions

### DIFF
--- a/test-libz-rs-sys/src/gz.rs
+++ b/test-libz-rs-sys/src/gz.rs
@@ -2,8 +2,8 @@ use zlib_rs::c_api::*;
 
 use z_rs::{
     gzFile_s, gzbuffer, gzclearerr, gzclose, gzclose_r, gzclose_w, gzdirect, gzdopen, gzerror,
-    gzflush, gzfread, gzfwrite, gzgetc, gzgetc_, gzgets, gzoffset, gzopen, gzputc, gzputs, gzread,
-    gzrewind, gzseek, gzsetparams, gztell, gzungetc, gzwrite,
+    gzflush, gzfread, gzfwrite, gzgetc, gzgetc_, gzgets, gzoffset, gzopen, gzopen64, gzputc,
+    gzputs, gzread, gzrewind, gzseek, gzsetparams, gztell, gzungetc, gzwrite,
 };
 
 use libc::size_t;
@@ -180,7 +180,7 @@ fn gz_error_access() {
     // Open a valid gzip file; the error should be an empty string
     let path = CString::new(crate_path("src/test-data/issue-109.gz")).unwrap();
     let mode = CString::new("r").unwrap();
-    let handle = unsafe { gzopen(path.as_ptr(), mode.as_ptr()) };
+    let handle = unsafe { gzopen64(path.as_ptr(), mode.as_ptr()) };
     assert!(!handle.is_null());
     let mut gz_errno: c_int = UNSET_ERRNO;
     let err = unsafe { gzerror(handle, &mut gz_errno as *mut c_int) };


### PR DESCRIPTION
zlib exposes 64-bit versions of some functions. Now we do too.

```
> objdump -T /usr/lib/x86_64-linux-gnu/libz.so | grep "64"
/usr/lib/x86_64-linux-gnu/libz.so:     file format elf64-x86-64
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) lseek64
0000000000010d40 g    DF .text	0000000000000011  ZLIB_1.2.3.3 gzopen64
0000000000008c70 g    DF .text	0000000000000009  ZLIB_1.2.3.3 crc32_combine64
0000000000010ef0 g    DF .text	0000000000000192  ZLIB_1.2.3.3 gzseek64
00000000000110f0 g    DF .text	000000000000005e  ZLIB_1.2.3.5 gzoffset64
00000000000074e0 g    DF .text	00000000000000e7  ZLIB_1.2.3.3 adler32_combine64
00000000000110a0 g    DF .text	0000000000000038  ZLIB_1.2.3.3 gztell64
```

```
> objdump -T target/debug/libz_rs.so | grep "64"
target/debug/libz_rs.so:     file format elf64-x86-64
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.33) stat64
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) mmap64
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) open64
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.2.5) lseek64
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.33) fstat64
000000000001ada0 g    DF .text	000000000000001f  Base        crc32_combine64
0000000000017e10 g    DF .text	0000000000000139  Base        gzoffset64
000000000001aed0 g    DF .text	000000000000007f  Base        adler32_combine64
000000000001c640 g    DF .text	00000000000001a5  Base        deflate
0000000000013c00 g    DF .text	000000000000005b  Base        gzopen64
0000000000019090 g    DF .text	0000000000000576  Base        gzseek64
0000000000017cf0 g    DF .text	00000000000000e4  Base        gztell64
```

In zlib-ng they seem to be using some preprocessor magic and relying on the 64-bit version being abi-compatible with the 32-bit version. We just duplicate the definitions like stock zlib, because then we can provide documentation.
