### PR TITLE
libz-rs-sys: Build static and shared variants

### DIFF
--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -22,3 +22,6 @@ semver-prefix = ["export-symbols"] # prefix all symbols in a semver-compatible w
 
 [dependencies]
 zlib-rs = { workspace = true, default-features = false }
+
+[lib]
+crate-type = ["cdylib", "lib", "staticlib"]


### PR DESCRIPTION
Used by the Android project to inform our import tools to generate the build rules necessary for linking this crate from C/C++.