### PR TITLE
experiment with the `SymBuf` representation

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1,6 +1,8 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 use core::{ffi::CStr, marker::PhantomData, mem::MaybeUninit, ops::ControlFlow};
 
+use sym_buf::Symbol;
+
 use crate::{
     adler32::adler32,
     allocate::Allocator,
@@ -1168,10 +1170,10 @@ impl<'a> BitWriter<'a> {
     }
 
     fn compress_block_help(&mut self, sym_buf: &SymBuf, ltree: &[Value], dtree: &[Value]) {
-        for (dist, lc) in sym_buf.iter() {
+        for Symbol { dist, len, .. } in sym_buf.iter() {
             match dist {
-                0 => self.emit_lit(ltree, lc) as usize,
-                _ => self.emit_dist(ltree, dtree, lc, dist),
+                0 => self.emit_lit(ltree, len) as usize,
+                _ => self.emit_dist(ltree, dtree, len, dist),
             };
         }
 
@@ -1540,10 +1542,10 @@ impl<'a> State<'a> {
 
     fn compress_block_static_trees(&mut self) {
         let ltree = self::trees_tbl::STATIC_LTREE.as_slice();
-        for (dist, lc) in self.sym_buf.iter() {
+        for Symbol { dist, len, .. } in self.sym_buf.iter() {
             match dist {
-                0 => self.bit_writer.emit_lit(ltree, lc) as usize,
-                _ => self.bit_writer.emit_dist_static(lc, dist),
+                0 => self.bit_writer.emit_lit(ltree, len) as usize,
+                _ => self.bit_writer.emit_dist_static(len, dist),
             };
         }
 

--- a/zlib-rs/src/deflate/pending.rs
+++ b/zlib-rs/src/deflate/pending.rs
@@ -61,7 +61,7 @@ impl<'a> Pending<'a> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     #[track_caller]
     pub fn extend(&mut self, buf: &[u8]) {
         assert!(


### PR DESCRIPTION
@brianpane you might enjoy playing around with this.

I get some actual speedup for compression level 3, it appears to be pretty neutral for the others. In `zlib-ng`, they actually use 2 arrays, which I did try but only gave instruction count improvements, not cycles/wall time.

I think the padding field is important because it makes initialization as just all zeros possible, which is efficient for the `fill` operations.

but well there is still the ordering of the fields, maybe `#[repr(packed)]` is useful, and maybe there are other ideas still.