### PR TITLE
Strengthen the lint directives related to unsafe code

### DIFF
--- a/libz-rs-sys-cdylib/Cargo.toml
+++ b/libz-rs-sys-cdylib/Cargo.toml
@@ -20,6 +20,9 @@ panic = "abort" # abort on panics. This is crucial, unwinding would cause UB!
 [profile.release]
 panic = "abort" # abort on panics. This is crucial, unwinding would cause UB!
 
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
 [features]
 default = ["c-allocator"] # when used as a cdylib crate, use the c allocator
 c-allocator = ["libz-rs-sys/c-allocator"] # by default, use malloc/free for memory allocation

--- a/libz-rs-sys-cdylib/src/gz.rs
+++ b/libz-rs-sys-cdylib/src/gz.rs
@@ -1,5 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
-
 use zlib_rs::allocate::*;
 pub use zlib_rs::c_api::*;
 

--- a/libz-rs-sys/Cargo.toml
+++ b/libz-rs-sys/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
 [features]
 default = ["std", "rust-allocator"] # when used as a rust crate, use the rust allocator
 c-allocator = ["zlib-rs/c-allocator"] # by default, use malloc/free for memory allocation

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_op_in_unsafe_fn)] // FIXME
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/zlib-rs/src/adler32.rs
+++ b/zlib-rs/src/adler32.rs
@@ -1,5 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
-
 #[cfg(target_arch = "x86_64")]
 mod avx2;
 mod generic;

--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -1,4 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
 use crate::CRC32_INITIAL_VALUE;
 
 #[cfg(target_arch = "aarch64")]

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1,4 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
 use core::{ffi::CStr, marker::PhantomData, mem::MaybeUninit, ops::ControlFlow};
 
 use crate::{

--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use crate::deflate::{State, HASH_SIZE, STD_MIN_MATCH};
 
 #[derive(Debug, Clone, Copy)]

--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_op_in_unsafe_fn)] // FIXME
+
 use core::fmt;
 use core::mem::MaybeUninit;
 use core::ops::Range;
@@ -18,6 +20,10 @@ impl<'a> Writer<'a> {
     }
 
     /// Creates a new `Writer` from an uninitialized buffer.
+    ///
+    /// # Safety
+    ///
+    /// The arguments must satisfy the requirements of [`core::slice::from_raw_parts_mut`].
     #[inline]
     pub unsafe fn new_uninit(ptr: *mut u8, len: usize) -> Writer<'a> {
         let buf = unsafe { WeakSliceMut::from_raw_parts_mut(ptr as *mut MaybeUninit<u8>, len) };


### PR DESCRIPTION
* Make deny(unsafe_op_in_unsafe_fn) the default
* Add forbid(unsafe_code) to hash_calc.rs now that it no longer contains unsafe code
* Document a few additional safety preconditions