### PR TITLE
zlib-rs: properly guard tests by allocator

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -125,6 +125,13 @@ jobs:
       - name: cargo build
         run: cargo build --target ${{matrix.target}} ${{ matrix.flags }}
 
+      # ensure tests for "real" features work standalone
+      - name: cargo test --no-default-features --features ...
+        run: |
+          cargo test --target ${{matrix.target}} ${{ matrix.flags }} --no-default-features --features c-allocator
+          cargo test --target ${{matrix.target}} ${{ matrix.flags }} --no-default-features --features rust-allocator
+
+
       # run tests
       - name: cargo llvm-cov nextest
         if: matrix.codecov

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -3309,6 +3309,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "c-allocator")]
     unsafe extern "C" fn fail_nth_allocation<const N: usize>(
         opaque: crate::c_api::voidpf,
         items: crate::c_api::uInt,
@@ -3327,6 +3328,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "c-allocator")]
     fn init_invalid_allocator() {
         {
             let atomic = AtomicUsize::new(0);
@@ -3371,6 +3373,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "c-allocator")]
     mod copy_invalid_allocator {
         use super::*;
 

--- a/zlib-rs/src/inflate/window.rs
+++ b/zlib-rs/src/inflate/window.rs
@@ -173,7 +173,7 @@ impl<'a> Window<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "rust-allocator"))]
 mod test {
     use super::*;
 


### PR DESCRIPTION
so that both `cargo test --no-default-features --features c-allocator` and `cargo test --no-default-features --features rust-allocator` pass.

in Debian packaging, we test each feature on its own, the default features, and all features combined (the latter doesn't work upstream either, but since we drop the fuzzing/debugging related features downstream, it does work for us with this commit here).