### PR TITLE
work around miri limitation, run more deflate tests with miri

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -458,6 +458,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
           - target: x86_64-pc-windows-gnu
+    env:
+      QUICKCHECK_TESTS: 10
     steps:
       - uses: actions/checkout@v3
       - name: Install Miri

--- a/test-libz-rs-sys/src/lib.rs
+++ b/test-libz-rs-sys/src/lib.rs
@@ -453,7 +453,6 @@ mod null {
             ..Default::default()
         };
 
-        #[cfg(not(miri))]
         assert_eq_rs_ng!({
             let mut extra = *b"banana\0";
             let mut name = *b"apple\0";
@@ -835,7 +834,6 @@ mod null {
     fn deflate_params() {
         assert_eq_rs_ng!({ deflateParams(core::ptr::null_mut(), 6, 0) });
 
-        #[cfg(not(miri))]
         assert_eq_rs_ng!({
             let mut strm = MaybeUninit::<z_stream>::zeroed();
             deflateInit_(
@@ -868,7 +866,6 @@ mod null {
             deflateSetHeader(core::ptr::null_mut(), head.as_mut_ptr())
         });
 
-        #[cfg(not(miri))]
         assert_eq_rs_ng!({
             let mut strm = MaybeUninit::<z_stream>::zeroed();
 
@@ -899,7 +896,6 @@ mod null {
             )
         });
 
-        #[cfg(not(miri))]
         assert_eq_rs_ng!({
             let mut strm = MaybeUninit::<z_stream>::zeroed();
             deflateInit_(
@@ -939,7 +935,6 @@ mod null {
             );
         }
 
-        #[cfg(not(miri))]
         assert_eq!(
             unsafe {
                 use libz_rs_sys::*;
@@ -967,7 +962,6 @@ mod null {
     pub const FERRIS_BYTES: [u8; 14] = [120u8, 156, 115, 75, 45, 42, 202, 44, 6, 0, 8, 6, 2, 108];
 
     #[test]
-    #[cfg_attr(miri, ignore = "slow")]
     fn ferris_bytes() {
         let input = b"Ferris";
         let mut buf = [0; 64];
@@ -1152,7 +1146,6 @@ mod null {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "slow")]
     fn deflate_init_uninitialized() {
         use libz_rs_sys::*;
 

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -804,7 +804,16 @@ fn lm_init(state: &mut State) {
     state.window_size = 2 * state.w_size;
 
     // zlib uses CLEAR_HASH here
-    state.head.as_mut_slice().fill(0);
+    crate::cfg_select!(
+        miri => {
+            // Miri does not turn `.fill(0)` into a memset
+            // See https://github.com/rust-lang/rust/issues/147271.
+            unsafe { core::ptr::write_bytes(state.head.as_mut_ptr(), 0u8, 1) };
+        }
+        _ => {
+            state.head.as_mut_slice().fill(0);
+        }
+    );
 
     // Set the default configuration parameters:
     lm_set_level(state, state.level);

--- a/zlib-rs/src/deflate/sym_buf.rs
+++ b/zlib-rs/src/deflate/sym_buf.rs
@@ -36,7 +36,16 @@ impl<'a> SymBuf<'a> {
     /// The number of initialized bytes is not changed, and the contents of the buffer are not modified.
     #[inline]
     pub fn clear(&mut self) {
-        self.buf.as_mut_slice().fill(0);
+        crate::cfg_select!(
+            miri => {
+                // Miri does not turn `.fill(0)` into a memset
+                // See https://github.com/rust-lang/rust/issues/147271.
+                unsafe { core::ptr::write_bytes(self.buf.as_mut_ptr(), 0u8, self.buf.len()) };
+            }
+            _ => {
+                self.buf.as_mut_slice().fill(0);
+            }
+        );
         self.filled = 0;
     }
 

--- a/zlib-rs/src/lib.rs
+++ b/zlib-rs/src/lib.rs
@@ -26,6 +26,27 @@ macro_rules! trace {
     };
 }
 
+#[macro_export]
+macro_rules! cfg_select {
+    ({ $($tt:tt)* }) => {{
+        $crate::cfg_select! { $($tt)* }
+    }};
+    (_ => { $($output:tt)* }) => {
+        $($output)*
+    };
+    (
+        $cfg:meta => $output:tt
+        $($( $rest:tt )+)?
+    ) => {
+        #[cfg($cfg)]
+        $crate::cfg_select! { _ => $output }
+        $(
+            #[cfg(not($cfg))]
+            $crate::cfg_select! { $($rest)+ }
+        )?
+    }
+}
+
 /// Maximum size of the dynamic table.  The maximum number of code structures is
 /// 1924, which is the sum of 1332 for literal/length codes and 592 for distance
 /// codes.  These values were found by exhaustive searches using the program


### PR DESCRIPTION
Miri does not currently turn `.fill(0)`  into a memset: https://github.com/rust-lang/miri/issues/4616.

There may be some ways to make that work, but for now we can at least run more deflate tests with miri by adding some special miri-only unsafe code that does use a `memset` internally.