### PR TITLE
Mr/guard simd tests

### DIFF
--- a/zlib-rs/src/adler32/avx2.rs
+++ b/zlib-rs/src/adler32/avx2.rs
@@ -145,7 +145,11 @@ unsafe fn helper_32_bytes(mut adler0: u32, mut adler1: u32, src: &[__m256i]) -> 
 }
 
 #[cfg(test)]
-#[cfg(target_feature = "avx2")]
+#[cfg(all(
+    target_feature = "avx2",
+    target_feature = "bmi1",
+    target_feature = "bmi2"
+))]
 mod test {
     use super::*;
 


### PR DESCRIPTION
the `neon` and `avx512` adler32 tests currently require the `std` feature being enabled to work, since the CPU feature detection is based on it.

note that there is a slight inconsistency between the two test modules:
- neon assumes the target has the feature enabled
- avx tests only run if the target has it enabled

the former means that if the target is compiled without neon support, the tests would still fail. the latter means that the tests don't run on targets that don't have avx enabled, but could support it at runtime if the CPU does (e.g., Debian's amd64 doesn't have AVX enabled automatically, but most modern CPUs support it)..

ideally, the runtime detection would just cause those tests to be skipped, instead of making them fail..