### PR TITLE
a slice fill is now turned into a memset even when using miri

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -804,16 +804,7 @@ fn lm_init(state: &mut State) {
     state.window_size = 2 * state.w_size;
 
     // zlib uses CLEAR_HASH here
-    crate::cfg_select!(
-        miri => {
-            // Miri does not turn `.fill(0)` into a memset
-            // See https://github.com/rust-lang/rust/issues/147271.
-            unsafe { core::ptr::write_bytes(state.head.as_mut_ptr(), 0u8, 1) };
-        }
-        _ => {
-            state.head.as_mut_slice().fill(0);
-        }
-    );
+    state.head.as_mut_slice().fill(0);
 
     // Set the default configuration parameters:
     lm_set_level(state, state.level);

--- a/zlib-rs/src/deflate/sym_buf.rs
+++ b/zlib-rs/src/deflate/sym_buf.rs
@@ -36,16 +36,7 @@ impl<'a> SymBuf<'a> {
     /// The number of initialized bytes is not changed, and the contents of the buffer are not modified.
     #[inline]
     pub fn clear(&mut self) {
-        crate::cfg_select!(
-            miri => {
-                // Miri does not turn `.fill(0)` into a memset
-                // See https://github.com/rust-lang/rust/issues/147271.
-                unsafe { core::ptr::write_bytes(self.buf.as_mut_ptr(), 0u8, self.buf.len()) };
-            }
-            _ => {
-                self.buf.as_mut_slice().fill(0);
-            }
-        );
+        self.buf.as_mut_slice().fill(0);
         self.filled = 0;
     }
 

--- a/zlib-rs/src/lib.rs
+++ b/zlib-rs/src/lib.rs
@@ -26,27 +26,6 @@ macro_rules! trace {
     };
 }
 
-#[macro_export]
-macro_rules! cfg_select {
-    ({ $($tt:tt)* }) => {{
-        $crate::cfg_select! { $($tt)* }
-    }};
-    (_ => { $($output:tt)* }) => {
-        $($output)*
-    };
-    (
-        $cfg:meta => $output:tt
-        $($( $rest:tt )+)?
-    ) => {
-        #[cfg($cfg)]
-        $crate::cfg_select! { _ => $output }
-        $(
-            #[cfg(not($cfg))]
-            $crate::cfg_select! { $($rest)+ }
-        )?
-    }
-}
-
 /// Maximum size of the dynamic table.  The maximum number of code structures is
 /// 1924, which is the sum of 1332 for literal/length codes and 592 for distance
 /// codes.  These values were found by exhaustive searches using the program


### PR DESCRIPTION
The fix from https://github.com/rust-lang/rust/pull/147457 should resolve the slow runtimes we were seeing.