### PR TITLE
zlib-rs: adapt neon CPU feature check to avx2 one

### DIFF
--- a/zlib-rs/src/cpu_features.rs
+++ b/zlib-rs/src/cpu_features.rs
@@ -81,8 +81,13 @@ pub fn is_enabled_pclmulqdq() -> bool {
 #[inline(always)]
 pub fn is_enabled_neon() -> bool {
     #[cfg(target_arch = "aarch64")]
-    #[cfg(feature = "std")]
-    return std::arch::is_aarch64_feature_detected!("neon");
+    {
+        #[cfg(target_feature = "neon")]
+        return true;
+
+        #[cfg(feature = "std")]
+        return std::arch::is_aarch64_feature_detected!("neon");
+    }
 
     false
 }


### PR DESCRIPTION
if the "neon" target feature is statically enabled, skip runtime detection. this allows running and passing the "neon" adler32 tests without requiring the "std" feature.