### PR TITLE
cdylib: add symbol versioning CI job

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -390,6 +390,13 @@ jobs:
         run: |
           cargo build --release --target ${{matrix.target}} --features=semver-prefix
           objdump -tT target/${{matrix.target}}/release/deps/libz_rs.so | grep -q -E "LIBZ_RS_SYS_v0.[0-9]+.x_uncompress" || (echo "symbol not found!" && exit 1)
+      - name: "cdylib: versioned symbols"
+        working-directory: libz-rs-sys-cdylib
+        run: |
+          cargo build --release --target ${{matrix.target}} --features=gz
+          cc -shared -Wl,--whole-archive target/${{matrix.target}}/release/libz_rs.a -Wl,--no-whole-archive -Wl,--version-script=include/zlib.map -Wl,--undefined-version -Wl,-soname,libz_rs.so.1 -lc -o target/${{matrix.target}}/release/libz_rs.versioned.so
+          objdump -T target/${{matrix.target}}/release/libz_rs.versioned.so | grep "ZLIB"
+          objdump -T target/${{matrix.target}}/release/libz_rs.versioned.so | grep -q -E "ZLIB_1.2.2.3 deflateTune" || (echo "symbol not found!" && exit 1)
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind
       - name: "cdylib: example.c"
         env:

--- a/libz-rs-sys-cdylib/Cargo.toml
+++ b/libz-rs-sys-cdylib/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75" # MSRV
 
 [lib]
 name = "z_rs" # turns into e.g. `libz_rs.so`
-crate-type = ["cdylib", "lib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 
 [profile.dev]
 panic = "abort" # abort on panics. This is crucial, unwinding would cause UB!

--- a/libz-rs-sys/include/zlib.map
+++ b/libz-rs-sys/include/zlib.map
@@ -1,0 +1,99 @@
+ZLIB_1.2.0 {
+  global:
+    compressBound;
+    deflateBound;
+    inflateBack;
+    inflateBackEnd;
+    inflateBackInit_;
+    inflateCopy;
+  local:
+    deflate_copyright;
+    inflate_copyright;
+    zcalloc;
+    zcfree;
+    z_errmsg;
+    gz_error;
+    gz_intmax;
+    rust_eh_personality;
+    _*;
+};
+
+ZLIB_1.2.0.2 {
+    gzclearerr;
+    gzungetc;
+    zlibCompileFlags;
+} ZLIB_1.2.0;
+
+ZLIB_1.2.0.8 {
+    deflatePrime;
+} ZLIB_1.2.0.2;
+
+ZLIB_1.2.2 {
+    adler32_combine;
+    crc32_combine;
+    deflateSetHeader;
+    inflateGetHeader;
+} ZLIB_1.2.0.8;
+
+ZLIB_1.2.2.3 {
+    deflateTune;
+    gzdirect;
+} ZLIB_1.2.2;
+
+ZLIB_1.2.2.4 {
+    inflatePrime;
+} ZLIB_1.2.2.3;
+
+ZLIB_1.2.3.3 {
+    adler32_combine64;
+    crc32_combine64;
+    gzopen64;
+    gzseek64;
+    gztell64;
+    inflateUndermine;
+} ZLIB_1.2.2.4;
+
+ZLIB_1.2.3.4 {
+    inflateReset2;
+    inflateMark;
+} ZLIB_1.2.3.3;
+
+ZLIB_1.2.3.5 {
+    gzbuffer;
+    gzoffset;
+    gzoffset64;
+    gzclose_r;
+    gzclose_w;
+} ZLIB_1.2.3.4;
+
+ZLIB_1.2.5.1 {
+    deflatePending;
+} ZLIB_1.2.3.5;
+
+ZLIB_1.2.5.2 {
+    deflateResetKeep;
+    gzgetc_;
+    inflateResetKeep;
+} ZLIB_1.2.5.1;
+
+ZLIB_1.2.7.1 {
+    inflateGetDictionary;
+    gzvprintf;
+} ZLIB_1.2.5.2;
+
+ZLIB_1.2.9 {
+    inflateCodesUsed;
+    inflateValidate;
+    uncompress2;
+    gzfread;
+    gzfwrite;
+    deflateGetDictionary;
+    adler32_z;
+    crc32_z;
+} ZLIB_1.2.7.1;
+
+ZLIB_1.2.12 {
+    crc32_combine_gen;
+    crc32_combine_gen64;
+    crc32_combine_op;
+} ZLIB_1.2.9;


### PR DESCRIPTION
fixes #419 

This adds the symbol version file, and a CI job to post-process the output to apply those versions. That is kind of the best we can do at present, because rust provides its own symbol version file and most linkers (except `mold`) use the first symbol file, ignoring ours.