### PR TITLE
Set Z_HAVE_UNISTD_H only on non-Windows platforms

### DIFF
--- a/libz-rs-sys/include/zconf.h
+++ b/libz-rs-sys/include/zconf.h
@@ -291,7 +291,7 @@ typedef void       *voidp;
 
 typedef unsigned int z_crc_t;
 
-#if 1    /* may be set to #if 1 by configure/cmake/etc */
+#if !defined(_WIN32)
 #  define Z_HAVE_UNISTD_H
 #endif
 


### PR DESCRIPTION
`unisdt.h` does not exist on Windows and therefore `Z_HAVE_UNISTD_H` should not be set.

When trying to use zlib-rs on Windows I received the following:
```
fatal error: 'unistd.h' file not found
  316 | #  include <unistd.h>         /* for SEEK_*, off_t, and _LFS64_LARGEFILE */
      |            ^~~~~~~~~~
1 error generated.
```