### PR TITLE
Simplify the emit_match function in the medium deflate algorithm

### DIFF
--- a/zlib-rs/src/deflate/algorithm/medium.rs
+++ b/zlib-rs/src/deflate/algorithm/medium.rs
@@ -192,7 +192,6 @@ fn emit_match(state: &mut State, m: Match) -> bool {
     if (m.match_length as usize) < WANT_MIN_MATCH {
         for lc in &state.window.filled()[state.strstart..][..m.match_length as usize] {
             bflush |= State::tally_lit_help(&mut state.sym_buf, &mut state.l_desc, *lc);
-            state.lookahead -= 1;
         }
     } else {
         // check_match(s, m.strstart, m.match_start, m.match_length);
@@ -201,9 +200,8 @@ fn emit_match(state: &mut State, m: Match) -> bool {
             (m.strstart - m.match_start) as usize,
             m.match_length as usize - STD_MIN_MATCH,
         );
-
-        state.lookahead -= m.match_length as usize;
     }
+    state.lookahead -= m.match_length as usize;
 
     bflush
 }


### PR DESCRIPTION
Based on the generated assembly, the compiler doesn't seem do this (small) optimization automatically.