### PR TITLE
Remove no-op `as _` casts with return codes

### DIFF
--- a/test-libz-rs-sys/examples/blogpost-compress.rs
+++ b/test-libz-rs-sys/examples/blogpost-compress.rs
@@ -82,7 +82,7 @@ fn compress_rs(
         }
     };
 
-    if ReturnCode::from(err) != ReturnCode::Ok as _ {
+    if ReturnCode::from(err) != ReturnCode::Ok {
         return ReturnCode::from(err);
     }
 
@@ -163,7 +163,7 @@ fn compress_ng(
         }
     };
 
-    if ReturnCode::from(err) != ReturnCode::Ok as _ {
+    if ReturnCode::from(err) != ReturnCode::Ok {
         return ReturnCode::from(err);
     }
 

--- a/test-libz-rs-sys/examples/compress.rs
+++ b/test-libz-rs-sys/examples/compress.rs
@@ -156,7 +156,7 @@ fn compress_rs(
         }
     };
 
-    if ReturnCode::from(err) != ReturnCode::Ok as _ {
+    if ReturnCode::from(err) != ReturnCode::Ok {
         return ReturnCode::from(err);
     }
 
@@ -237,7 +237,7 @@ fn compress_ng(
         }
     };
 
-    if ReturnCode::from(err) != ReturnCode::Ok as _ {
+    if ReturnCode::from(err) != ReturnCode::Ok {
         return ReturnCode::from(err);
     }
 

--- a/test-libz-rs-sys/src/helpers.rs
+++ b/test-libz-rs-sys/src/helpers.rs
@@ -160,14 +160,14 @@ pub fn uncompress_slice_ng<'a>(
         let err = unsafe { libz_ng_sys::inflate(&mut stream, InflateFlush::NoFlush as _) };
         let err = ReturnCode::from(err);
 
-        if err != ReturnCode::Ok as _ {
+        if err != ReturnCode::Ok {
             break err;
         }
     };
 
     if dest_len != 0 {
         dest_len_ptr = stream.total_out;
-    } else if stream.total_out != 0 && err == ReturnCode::BufError as _ {
+    } else if stream.total_out != 0 && err == ReturnCode::BufError {
         left = 1;
     }
 

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -3072,10 +3072,10 @@ pub unsafe fn set_header<'a>(
     head: Option<&'a mut gz_header>,
 ) -> ReturnCode {
     if stream.state.wrap != 2 {
-        ReturnCode::StreamError as _
+        ReturnCode::StreamError
     } else {
         stream.state.gzhead = head;
-        ReturnCode::Ok as _
+        ReturnCode::Ok
     }
 }
 

--- a/zlib-rs/src/inflate.rs
+++ b/zlib-rs/src/inflate.rs
@@ -2360,7 +2360,7 @@ pub fn codes_used(stream: &InflateStream) -> usize {
 
 pub unsafe fn inflate(stream: &mut InflateStream, flush: InflateFlush) -> ReturnCode {
     if stream.next_out.is_null() || (stream.next_in.is_null() && stream.avail_in != 0) {
-        return ReturnCode::StreamError as _;
+        return ReturnCode::StreamError;
     }
 
     let state = &mut stream.state;
@@ -2432,12 +2432,12 @@ pub unsafe fn inflate(stream: &mut InflateStream, flush: InflateFlush) -> Return
 
     stream.data_type = state.decoding_state();
 
-    if ((in_read == 0 && out_written == 0) || flush == InflateFlush::Finish as _)
-        && err == (ReturnCode::Ok as _)
+    if ((in_read == 0 && out_written == 0) || flush == InflateFlush::Finish)
+        && err == ReturnCode::Ok
     {
-        ReturnCode::BufError as _
+        ReturnCode::BufError
     } else {
-        err as _
+        err
     }
 }
 


### PR DESCRIPTION
Saw some of these while looking into the error logic for `compress_with_flush`. It seems like clippy doesn't complain about always-trivial `as _` casts (and finding these without false-positives for platform-specific stuff seems hard).