### PR TITLE
add test for deterministic deflate output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ opt-level = 1 # required for the tail calls in inflate to optimize
 
 [workspace.dependencies]
 libloading = "0.8.1"
-libz-sys = { version = "1.1.23", default-features = false, features = ["zlib-ng"] } # use libz-ng in libz compat mode
+libz-sys = { version = "1.1.24", default-features = false, features = ["zlib-ng"] } # use libz-ng in libz compat mode
 arbitrary = { version = "1.0" }
 quickcheck = { version = "1.0.3", default-features = false, features = [] }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ features = ["arbitrary-derive"]
 
 [dependencies]
 libc = "0.2.151"
-libz-ng-sys = "1.1.23"
+libz-ng-sys = "1.1.24"
 libloading = "0.8.1"
 crc32fast = "1.3.2"
 rstest = "0.23.0"

--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -254,8 +254,9 @@ fn longest_match_help<const SLOW: bool>(
         if len > best_len {
             match_start = cur_match - match_offset;
 
-            /* Do not look for matches beyond the end of the input. */
-            if len > lookahead {
+            // Do not look for better matches if the current match reaches
+            // or exceeds the end of the input. See also #459.
+            if len >= lookahead {
                 return (lookahead, match_start);
             }
             best_len = len;


### PR DESCRIPTION
fixes https://github.com/trifectatechfoundation/zlib-rs/issues/459

Compressing an input after a `reset` should give the same output as if it was done with a fresh compression state. There was a bug where some of the state from before the reset could influence what match was picked for later input. The output was still valid, but it is inconsistent.

Thank you @QrczakMK for the detective work here!