### PR TITLE
use `std` by default when building a `cdylib`

### DIFF
--- a/libz-rs-sys-cdylib/Cargo.toml
+++ b/libz-rs-sys-cdylib/Cargo.toml
@@ -20,18 +20,23 @@ panic = "abort" # abort on panics. This is crucial, unwinding would cause UB!
 [profile.release]
 panic = "abort" # abort on panics. This is crucial, unwinding would cause UB!
 
+[profile.relwithdebinfo]
+inherits = "release"
+debug = true
+
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
 
 [features]
-default = ["c-allocator"] # when used as a cdylib crate, use the c allocator
+default = ["c-allocator", "std"] # when used as a cdylib crate, use the c allocator but use std for feature detection
 c-allocator = ["libz-rs-sys/c-allocator"] # by default, use malloc/free for memory allocation
-rust-allocator = ["libz-rs-sys/rust-allocator", "libz-rs-sys/std"] # by default, use the rust global alloctor for memory allocation
+rust-allocator = ["libz-rs-sys/rust-allocator", "std"] # by default, use the rust global alloctor for memory allocation
 custom-prefix = ["libz-rs-sys/custom-prefix"] # use the LIBZ_RS_SYS_PREFIX to prefix all exported symbols
 semver-prefix = ["libz-rs-sys/semver-prefix"] # prefix all symbols in a semver-compatible way
+std = ["libz-rs-sys/std"] # enables runtime feature detection (e.g. to use SIMD)
 capi = []
 gz = ["dep:libc"] # support for the `gz*` functions is experimental
-gzprintf = []
+gzprintf = ["gz"]
 __internal-test = []
 
 [dependencies]


### PR DESCRIPTION
this will not enable the rust allocator, but does allow for runtime feature detection and therefore the use of custom SIMD implementations.

Using the zlib-ng C file for `minigzip` and their `deflatebench.py` script, we see roughly what our own benchmarks also tell us. I believe the difference for level 0 is that we don't combine the copy of the data with the checksum calculation (those are 2 separate passes in zlib-rs, combining them would require more unsafe code). 

### zlib-ng

```
OS: Linux 6.8.0-40-generic #40-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  5 10:34:03 UTC 2024 x86_64
CPU: x86_64
Tool: minigzip Size: 148,680 B
Timing: perf
Levels: 0-9       
Runs: 15         Trim worst: 5         

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0421/0.0500/0.0570/0.0056    0.0450/0.0550/0.0629/0.0059      535,075,728
 1     54.165%  1.0477/1.0668/1.0829/0.0126    0.3908/0.4033/0.4132/0.0080      153,422,996
 2     43.877%  0.9626/0.9719/0.9830/0.0075    0.1879/0.1977/0.2059/0.0060       62,140,932
 3     42.381%  0.8860/0.8925/0.8996/0.0043    0.1468/0.1509/0.1565/0.0038       46,684,570
 4     41.665%  0.8975/0.9059/0.9114/0.0043    0.1225/0.1292/0.1351/0.0048       39,338,830
 5     41.211%  1.0954/1.1040/1.1125/0.0052    0.1175/0.1264/0.1329/0.0051       38,910,121
 6     41.036%  1.0971/1.1026/1.1093/0.0038    0.0944/0.1031/0.1092/0.0054       32,287,513
 7     40.784%  1.1327/1.1491/1.1573/0.0073    0.0793/0.0827/0.0850/0.0019       25,671,718
 8     40.707%  1.1034/1.1099/1.1152/0.0039    0.0588/0.0653/0.0693/0.0035       19,217,360
 9     40.419%  1.2748/1.2831/1.2930/0.0065    0.0559/0.0627/0.0657/0.0027       19,081,493

 avg1  48.625%                       0.9636                         0.1376
 avg2  54.028%                       1.0706                         0.1529
 tot                                96.3576                        13.7629      971,831,261
```

### zlib-rs

```
OS: Linux 6.8.0-40-generic #40-Ubuntu SMP PREEMPT_DYNAMIC Fri Jul  5 10:34:03 UTC 2024 x86_64
CPU: x86_64
Tool: minigzip Size: 6,456,664 B
Timing: perf
Levels: 0-9       
Runs: 15         Trim worst: 5         

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0559/0.0685/0.0859/0.0092    0.0549/0.0629/0.0680/0.0053      535,075,728
 1     54.186%  1.0235/1.0475/1.0639/0.0125    0.3762/0.3986/0.4099/0.0109      153,483,104
 2     43.877%  0.9459/0.9578/0.9659/0.0070    0.1832/0.1975/0.2025/0.0061       62,141,310
 3     42.382%  0.8773/0.8868/0.8999/0.0079    0.1354/0.1460/0.1515/0.0050       46,685,991
 4     41.665%  0.8933/0.8983/0.9021/0.0030    0.1180/0.1255/0.1314/0.0039       39,339,113
 5     41.210%  0.9794/0.9887/0.9952/0.0050    0.1178/0.1224/0.1250/0.0021       38,909,592
 6     41.036%  1.0032/1.0113/1.0191/0.0049    0.0926/0.0983/0.1024/0.0034       32,287,982
 7     40.784%  1.1657/1.1711/1.1762/0.0035    0.0756/0.0824/0.0873/0.0038       25,671,824
 8     40.707%  1.1183/1.1262/1.1313/0.0037    0.0591/0.0622/0.0653/0.0025       19,217,376
 9     40.419%  1.1871/1.1968/1.2044/0.0053    0.0507/0.0583/0.0624/0.0037       19,081,493

 avg1  48.627%                       0.9353                         0.1354
 avg2  54.030%                       1.0392                         0.1505
 tot                                93.5298                        13.5415      971,893,513
```
