### PR TITLE
gate tests on features they use

### DIFF
--- a/zlib-rs/src/adler32/neon.rs
+++ b/zlib-rs/src/adler32/neon.rs
@@ -200,7 +200,7 @@ unsafe fn accum32(s: (u32, u32), buf: &[uint8x16_t]) -> (u32, u32) {
     (vget_lane_u32(as_, 0), vget_lane_u32(as_, 1))
 }
 
-#[cfg(all(test, feature = "std", target_feature = "neon"))]
+#[cfg(all(test, feature = "std", any(miri, target_feature = "neon")))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/zlib-rs/debian/patches/fix-aarch64-neon-tests.patch?ref_type=heads