### PR TITLE
the zalloc_rust and zalloc_rust_calloc functions are behind the rust-allocator feature

### DIFF
--- a/zlib-rs/src/allocate.rs
+++ b/zlib-rs/src/allocate.rs
@@ -564,9 +564,13 @@ mod tests {
             assert!(zalloc_c(ptr::null_mut(), 0, 1).is_null());
             assert!(zalloc_c_calloc(ptr::null_mut(), 1, 0).is_null());
             assert!(zalloc_c_calloc(ptr::null_mut(), 0, 1).is_null());
+            #[cfg(feature = "rust-allocator")]
             assert!(zalloc_rust(ptr::null_mut(), 1, 0).is_null());
+            #[cfg(feature = "rust-allocator")]
             assert!(zalloc_rust(ptr::null_mut(), 0, 1).is_null());
+            #[cfg(feature = "rust-allocator")]
             assert!(zalloc_rust_calloc(ptr::null_mut(), 1, 0).is_null());
+            #[cfg(feature = "rust-allocator")]
             assert!(zalloc_rust_calloc(ptr::null_mut(), 0, 1).is_null());
         }
     }


### PR DESCRIPTION
the command:

```
cargo test --no-default-features --features c-allocator
```

stopped working between version 0.5 and 0.6, this PR restores it.

from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/zlib-rs/debian/patches/gate-c-allocator-feature.patch?ref_type=heads