### PR TITLE
cpu_features: add PPC64LE compile-time SIMD feature detection

### DIFF
--- a/zlib-rs/src/cpu_features.rs
+++ b/zlib-rs/src/cpu_features.rs
@@ -108,3 +108,30 @@ pub fn is_enabled_simd128() -> bool {
 
     false
 }
+
+// PowerPC 64-bit: compile-time only detection (no stable runtime detection available).
+// Enable with `-C target-feature=+altivec,+vsx` or `-C target-cpu=pwr8` (or higher).
+
+#[inline(always)]
+pub fn is_enabled_altivec() -> bool {
+    #[cfg(target_arch = "powerpc64")]
+    return cfg!(target_feature = "altivec");
+
+    false
+}
+
+#[inline(always)]
+pub fn is_enabled_vsx() -> bool {
+    #[cfg(target_arch = "powerpc64")]
+    return cfg!(target_feature = "vsx");
+
+    false
+}
+
+#[inline(always)]
+pub fn is_enabled_power9() -> bool {
+    #[cfg(target_arch = "powerpc64")]
+    return cfg!(target_feature = "power9-altivec");
+
+    false
+}


### PR DESCRIPTION
## Summary

- Add `is_enabled_altivec()`, `is_enabled_vsx()`, and `is_enabled_power9()` to `cpu_features.rs` for powerpc64 targets
- Uses compile-time detection via `cfg!(target_feature = ...)`, following the same pattern as wasm32/simd128

## Why?

This is groundwork for PPC64LE SIMD support. The `core::arch::powerpc64` intrinsics and `is_powerpc64_feature_detected!` macro are both nightly-only in Rust (tracked by rust-lang/rust#111145 (https://github.com/rust-lang/rust/issues/111145) and #111191 (https://github.com/rust-lang/rust/issues/111191)), so runtime detection is not possible on stable. Compile-time detection via `cfg!(target_feature)` is stable and is the same approach used for wasm32.

Users enable PPC64LE SIMD at build time with -C `target-feature=+altivec,+vsx` or `-C target-cpu=pwr8` (or higher).

## Testing
- Verified compilation on host (cargo check)
- Verified cross-compilation for powerpc64le-unknown-linux-gnu (cargo check --target powerpc64le-unknown-linux-gnu)
- Verified compilation with SIMD flags (RUSTFLAGS="-C target-feature=+altivec,+vsx" cargo check --target powerpc64le-unknown-linux-gnu)

## Future plan

Port features from the C Zlib