### PR TITLE
fix missing input validation in `inflateBackInit_`

### DIFF
--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -34,6 +34,7 @@ mod gz;
 #[cfg_attr(docsrs, doc(cfg(feature = "gz")))]
 #[cfg(feature = "gz")]
 pub use gz::*;
+use zlib_rs::{MAX_WBITS, MIN_WBITS};
 
 use core::mem::MaybeUninit;
 
@@ -618,7 +619,8 @@ pub unsafe extern "C" fn inflateEnd(strm: *mut z_stream) -> i32 {
 /// - [`Z_OK`] if success
 /// - [`Z_MEM_ERROR`] if there was not enough memory
 /// - [`Z_VERSION_ERROR`] if the zlib library version is incompatible with the version assumed by the caller
-/// - [`Z_STREAM_ERROR`] if a parameter is invalid, such as a null pointer to the structure
+/// - [`Z_STREAM_ERROR`] if a parameter is invalid, such as a null pointer to the `window` or an
+///   invalid `windowBits`.
 ///
 /// # Safety
 ///
@@ -634,6 +636,7 @@ pub unsafe extern "C" fn inflateEnd(strm: *mut z_stream) -> i32 {
 ///     - `zalloc`
 ///     - `zfree`
 ///     - `opaque`
+/// * The `window` pointer points to an allocation of `1 << windowBits` bytes
 #[cfg_attr(feature = "export-symbols", export_name = prefix!(inflateBackInit_))]
 pub unsafe extern "C" fn inflateBackInit_(
     strm: z_streamp,
@@ -649,6 +652,14 @@ pub unsafe extern "C" fn inflateBackInit_(
     let Some(strm) = (unsafe { strm.as_mut() }) else {
         return ReturnCode::StreamError as _;
     };
+
+    if window.is_null() {
+        return ReturnCode::StreamError as _;
+    }
+
+    if !(MIN_WBITS..=MAX_WBITS).contains(&windowBits) {
+        return ReturnCode::StreamError as _;
+    }
 
     let config = InflateConfig {
         window_bits: windowBits,

--- a/test-libz-rs-sys/src/infback.rs
+++ b/test-libz-rs-sys/src/infback.rs
@@ -2,6 +2,45 @@ use core::ffi::{c_int, c_uchar, c_uint, c_void};
 use core::mem::MaybeUninit;
 use libz_sys as libz_ng_sys;
 
+use crate::assert_eq_rs_ng;
+
+#[test]
+fn edge_cases() {
+    let mut tiny_window = [0u8; 16];
+
+    assert_eq!(
+        assert_eq_rs_ng! {
+            {
+                let mut stream = MaybeUninit::uninit();
+                inflateBackInit_(
+                    stream.as_mut_ptr(),
+                    20,
+                    tiny_window.as_mut_ptr(),
+                    zlibVersion(),
+                    core::mem::size_of::<z_stream>() as _ ,
+                )
+            }
+        },
+        libz_ng_sys::Z_STREAM_ERROR
+    );
+
+    assert_eq!(
+        assert_eq_rs_ng! {
+            {
+                let mut stream = MaybeUninit::uninit();
+                inflateBackInit_(
+                    stream.as_mut_ptr(),
+                    15,
+                    core::ptr::null_mut(),
+                    zlibVersion(),
+                    core::mem::size_of::<z_stream>() as _ ,
+                )
+            }
+        },
+        libz_ng_sys::Z_STREAM_ERROR
+    );
+}
+
 #[test]
 fn blow_up_the_stack_1() {
     const INPUT: &[u8] = include_bytes!("test-data/blow_up_the_stack_1.gz");

--- a/zlib-rs/src/inflate/infback.rs
+++ b/zlib-rs/src/inflate/infback.rs
@@ -10,6 +10,7 @@ use crate::inflate::{
     INFLATE_FAST_MIN_HAVE, INFLATE_FAST_MIN_LEFT, INFLATE_STRICT, MAX_BITS, MAX_DIST_EXTRA_BITS,
 };
 use crate::{c_api::z_stream, inflate::writer::Writer, ReturnCode};
+use crate::{MAX_WBITS, MIN_WBITS};
 
 macro_rules! tracev {
     ($template:expr) => {
@@ -25,6 +26,10 @@ macro_rules! tracev {
 /// Initialize the stream in an inflate state
 pub fn back_init(stream: &mut z_stream, config: InflateConfig, window: Window) -> ReturnCode {
     assert_eq!(1 << config.window_bits, window.buffer_size());
+
+    if !(MIN_WBITS..=MAX_WBITS).contains(&config.window_bits) {
+        return ReturnCode::StreamError as _;
+    }
 
     stream.msg = core::ptr::null_mut();
 


### PR DESCRIPTION
cc @Shnatsel 

This API is, from what I have been able to tell, not actually used in the wild. Nevertheless we have to of course validate the inputs and prevent unsoundness. 