### PR TITLE
crc32: Add implementation for loongarch64

### DIFF
--- a/zlib-rs/src/crc32.rs
+++ b/zlib-rs/src/crc32.rs
@@ -6,6 +6,8 @@ use crate::CRC32_INITIAL_VALUE;
 pub(crate) mod acle;
 mod braid;
 mod combine;
+#[cfg(target_arch = "loongarch64")]
+mod loongarch;
 #[cfg(target_arch = "x86_64")]
 mod pclmulqdq;
 #[cfg(target_arch = "x86_64")]
@@ -81,8 +83,15 @@ impl Crc32Fold {
             return;
         }
 
-        // in this case the start value is ignored
-        self.value = braid::crc32_braid::<5>(self.value, src);
+        #[cfg(target_arch = "loongarch64")]
+        {
+            self.value = self::loongarch::crc32_loongarch64(self.value, src);
+        }
+        #[cfg(not(target_arch = "loongarch64"))]
+        {
+            // in this case the start value is ignored
+            self.value = braid::crc32_braid::<5>(self.value, src);
+        }
     }
 
     pub fn fold_copy(&mut self, dst: &mut [u8], src: &[u8]) {

--- a/zlib-rs/src/crc32/loongarch.rs
+++ b/zlib-rs/src/crc32/loongarch.rs
@@ -1,0 +1,118 @@
+pub fn crc32_loongarch64(crc: u32, buf: &[u8]) -> u32 {
+    let mut c = !crc as i32;
+
+    // SAFETY: [u8; 8] safely transmutes into i64.
+    let (before, middle, after) = unsafe { buf.align_to::<i64>() };
+
+    c = remainder(c, before);
+
+    if middle.is_empty() && after.is_empty() {
+        return !c as u32;
+    }
+
+    for d in middle {
+        c = crc_w_d_w(*d, c);
+    }
+
+    c = remainder(c, after);
+
+    !c as u32
+}
+
+#[inline]
+fn remainder(mut c: i32, mut buf: &[u8]) -> i32 {
+    if let [b0, b1, b2, b3, rest @ ..] = buf {
+        c = crc_w_w_w(i32::from_le_bytes([*b0, *b1, *b2, *b3]), c);
+        buf = rest;
+    }
+
+    if let [b0, b1, rest @ ..] = buf {
+        c = crc_w_h_w(i16::from_le_bytes([*b0, *b1]), c);
+        buf = rest;
+    }
+
+    if let [b0, rest @ ..] = buf {
+        c = crc_w_b_w(*b0 as i8, c);
+        buf = rest;
+    }
+
+    debug_assert!(buf.is_empty());
+
+    c
+}
+
+crate::cfg_select! {
+    miri => {
+        use core::arch::loongarch64::{crc_w_b_w, crc_w_h_w, crc_w_w_w, crc_w_d_w};
+    }
+    _ => {
+        use asm::{crc_w_b_w, crc_w_h_w, crc_w_w_w, crc_w_d_w};
+    }
+}
+
+// FIXME: there are intrinsics for these in the standard library, but currently
+// unstable behind the stdarch_loongarch feature
+//
+// CRC32 instructions are part of the basic integer operations and therefore
+// always available.
+mod asm {
+    /// CRC32 single round checksum for bytes (8 bits).
+    ///
+    /// [Loongson's documentation](https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions)
+    pub fn crc_w_b_w(data: i8, mut crc: i32) -> i32 {
+        unsafe {
+            core::arch::asm!(
+                "crc.w.b.w {crc}, {data}, {crc}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
+        }
+        crc
+    }
+
+    /// CRC32 single round checksum for half words (16 bits).
+    ///
+    /// [Loongson's documentation](https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions)
+    pub fn crc_w_h_w(data: i16, mut crc: i32) -> i32 {
+        unsafe {
+            core::arch::asm!(
+                "crc.w.h.w {crc}, {data}, {crc}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
+        }
+        crc
+    }
+
+    /// CRC32 single round checksum for words (32 bits).
+    ///
+    /// [Loongson's documentation](https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions)
+    pub fn crc_w_w_w(data: i32, mut crc: i32) -> i32 {
+        unsafe {
+            core::arch::asm!(
+                "crc.w.w.w {crc}, {data}, {crc}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
+        }
+        crc
+    }
+
+    /// CRC32 single round checksum for double words (64 bits).
+    ///
+    /// [Loongson's documentation](https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions)
+    pub fn crc_w_d_w(data: i64, mut crc: i32) -> i32 {
+        unsafe {
+            core::arch::asm!(
+                "crc.w.d.w {crc}, {data}, {crc}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
+        }
+        crc
+    }
+}


### PR DESCRIPTION
Promised @folkertdev I'd start working on this at RustWeek (hi!), so here's the very low hanging fruit: LoongArch has CRC32 instructions that are extremely similar to those on aarch64, but they're part of the base integer instruction set and therefore unconditionally available: https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions.

stdarch has intrinsics for these, see e.g. [here](https://doc.rust-lang.org/stable/core/arch/loongarch64/fn.crc_w_d_w.html), but they're nightly-only, so inline assembly is necessary to make this work on stable.

I think the function signatures in stdarch are terrible, they do match LLVM's, but a parameter where only the lower 8 bits are used should really just be a u8/i8 instead of an i32. I went with that approach for the re-implementation here and will see if I can get this changed in LLVM and stdarch. The choice of signed integers makes this uglier than the aarch64 implementation, but it matches stdarch, so I went with that. This also won't work in miri yet.

I'd love to add CI for loongarch64 here, but the cross compilers are only available in Ubuntu starting with 25.10 and 26.04, so we'll have to wait until GitHub adds a runner image based on that.

`cargo nextest run --features gz` passes for me on a Loongson 3B6000. Are there existing benchmarks for these implementations or do you always just copy the relevant parts out and run benchmarks separately when adding new implementations?

zlib-ng has managed to somewhat abstract over the aarch64 and loongarch64 intrinsics to share the implementation. Ideally we'd do something similar here, I guess we could wrap the intrinsics to have the same signatures?