### PR TITLE
fix and test `aarch64_be`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -654,6 +654,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu
+          - target: aarch64_be-unknown-linux-gnu
     env:
       QUICKCHECK_TESTS: 10
     steps:
@@ -661,11 +662,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           persist-credentials: false
+
       - name: Install Miri
         run: |
-          rustup target add ${{ matrix.target }}
           rustup toolchain install nightly --component miri
           cargo +nightly miri setup
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # v2.53.2
         with:

--- a/zlib-rs/src/adler32/neon.rs
+++ b/zlib-rs/src/adler32/neon.rs
@@ -4,7 +4,7 @@
 //! extension.
 use core::arch::aarch64::{
     uint16x8_t, uint16x8x2_t, uint16x8x4_t, uint8x16_t, vaddq_u32, vaddw_high_u8, vaddw_u8,
-    vdupq_n_u16, vdupq_n_u32, vget_high_u32, vget_lane_u32, vget_low_u16, vget_low_u32,
+    vdupq_n_u16, vdupq_n_u32, vextq_u8, vget_high_u32, vget_lane_u32, vget_low_u16, vget_low_u32,
     vget_low_u8, vld1q_u8_x4, vmlal_high_u16, vmlal_u16, vpadalq_u16, vpadalq_u8, vpadd_u32,
     vpaddlq_u8, vsetq_lane_u32, vshlq_n_u32,
 };
@@ -116,9 +116,27 @@ unsafe fn accum32(s: (u32, u32), buf: &[uint8x16_t]) -> (u32, u32) {
 
     let mut it = buf.chunks_exact(4);
 
+    #[target_feature(enable = "neon")]
+    #[inline]
+    fn swap_64bit_lanes_when_be(v: uint8x16_t) -> uint8x16_t {
+        crate::cfg_select! {
+            target_endian = "big" => { vextq_u8(v, v, 8) }
+            target_endian = "little" => { v }
+        }
+    }
+
     for chunk in &mut it {
         // SAFETY: the chunks_exact iterator ensures chunk always references a 16x4 block within buf.
-        let d0_d3 = unsafe { vld1q_u8_x4(chunk.as_ptr() as *const u8) };
+        let d0_d3 = {
+            let mut tmp = unsafe { vld1q_u8_x4(chunk.as_ptr() as *const u8) };
+
+            tmp.0 = swap_64bit_lanes_when_be(tmp.0);
+            tmp.1 = swap_64bit_lanes_when_be(tmp.1);
+            tmp.2 = swap_64bit_lanes_when_be(tmp.2);
+            tmp.3 = swap_64bit_lanes_when_be(tmp.3);
+
+            tmp
+        };
 
         // Unfortunately it doesn't look like there's a direct sum 8 bit to 32
         // bit instruction, we'll have to make due summing to 16 bits first
@@ -155,6 +173,7 @@ unsafe fn accum32(s: (u32, u32), buf: &[uint8x16_t]) -> (u32, u32) {
     if !remainder.is_empty() {
         let mut s3acc_0 = vdupq_n_u32(0);
         for d0 in remainder.iter().copied() {
+            let d0 = swap_64bit_lanes_when_be(d0);
             let adler: uint16x8_t = vpaddlq_u8(d0);
             s2_6 = vaddw_u8(s2_6, vget_low_u8(d0));
             s2_7 = vaddw_high_u8(s2_7, d0);

--- a/zlib-rs/src/crc32/acle.rs
+++ b/zlib-rs/src/crc32/acle.rs
@@ -18,7 +18,8 @@ pub unsafe fn crc32_acle_aarch64(crc: u32, buf: &[u8]) -> u32 {
     }
 
     for d in middle {
-        c = unsafe { __crc32d(c, *d) };
+        // Convert to LE if on BE.
+        c = unsafe { __crc32d(c, (*d).to_le()) };
     }
 
     // SAFETY: `remainder` requires the feature "crc" but so does this function

--- a/zlib-rs/src/deflate/compare256.rs
+++ b/zlib-rs/src/deflate/compare256.rs
@@ -114,7 +114,7 @@ mod rust {
 mod neon {
     use core::arch::aarch64::{
         uint8x16x4_t, vceqq_u8, vget_lane_u64, vld4q_u8, vreinterpret_u64_u8, vreinterpretq_u16_u8,
-        vshrn_n_u16, vsriq_n_u8,
+        vrev16q_u8, vshrn_n_u16, vsriq_n_u8,
     };
 
     /// # Safety
@@ -167,6 +167,13 @@ mod neon {
                 // shifting right by 4 bits means the top 4 bits of each 16 bit element contains the
                 // low 4 bits of the 0th 8-bit element and the high 4 bits of the 1nth 8-bit
                 // element. Narrowing takes the top 8 bits of each (16-bit) element.
+                let bitmask_vector = if cfg!(target_endian = "big") {
+                    // We interpret this as u16 below; on BE swap the bytes around.
+                    vrev16q_u8(bitmask_vector)
+                } else {
+                    bitmask_vector
+                };
+
                 let result_vector = vshrn_n_u16::<4>(vreinterpretq_u16_u8(bitmask_vector));
 
                 // Convert the vector to a 64-bit integer, where each bit represents whether


### PR DESCRIPTION
So this is obviously a tier 3 target that we do not need to support, however:

- we promise to be portable, and hence should try hard to in fact be portable (e.g. for firefox and who knows where we end up)
- as a co-maintainer of stdarch I both would like to notice issues early and can fix them myself when they come up