### PR TITLE
Use the stock zlib crc32 approach on aarch64

### DIFF
--- a/zlib-rs/src/crc32/acle.rs
+++ b/zlib-rs/src/crc32/acle.rs
@@ -1,31 +1,77 @@
 //! # Safety
 //!
 //! The functions in this module must only be executed on an ARM system with the CRC feature.
+use super::combine::{multmodp, x2nmodp};
 
-#[cfg_attr(not(target_arch = "aarch64"), allow(unused))]
+// Constants empirically determined to maximize speed. These values are from
+// measurements on a Cortex-A57. Your mileage may vary.
+const Z_BATCH: usize = 3990;
+const Z_BATCH_ZEROS: u32 = x2nmodp(Z_BATCH as u64, 6);
+const _: () = assert!(Z_BATCH_ZEROS == 0xa10d3d0c);
+const Z_BATCH_MIN: usize = 800;
+
+/// 3-way interleaved ARM CRC32, ported from stock zlib's ARMCRC32 path.
+///
+/// Runs three independent crc32x streams simultaneously to exploit the
+/// ~3-cycle throughput of the instruction, then combines them with
+/// polynomial multiplication.
+///
+/// Based on the ARMCRC32 code path in stock zlib.
 #[target_feature(enable = "crc")]
 pub unsafe fn crc32_acle_aarch64(crc: u32, buf: &[u8]) -> u32 {
-    let mut c = !crc;
+    let mut crc = !crc;
 
     // SAFETY: [u8; 8] safely transmutes into u64.
     let (before, middle, after) = unsafe { buf.align_to::<u64>() };
 
-    // SAFETY: `remainder` requires the feature "crc" but so does this function
-    c = unsafe { remainder(c, before) };
+    // SAFETY: requires the "crc" feature.
+    crc = unsafe { remainder(crc, before) };
 
-    if middle.is_empty() && after.is_empty() {
-        return !c;
+    let mut words = middle;
+
+    while words.len() >= 3 * Z_BATCH {
+        let mut crc1: u32 = 0;
+        let mut crc2: u32 = 0;
+        for i in 0..Z_BATCH {
+            // SAFETY: requires the "crc" feature.
+            unsafe {
+                crc = __crc32d(crc, words[i].to_le());
+                crc1 = __crc32d(crc1, words[i + Z_BATCH].to_le());
+                crc2 = __crc32d(crc2, words[i + 2 * Z_BATCH].to_le());
+            }
+        }
+        words = &words[3 * Z_BATCH..];
+        crc = multmodp(Z_BATCH_ZEROS, crc) ^ crc1;
+        crc = multmodp(Z_BATCH_ZEROS, crc) ^ crc2;
     }
 
-    for d in middle {
-        // Convert to LE if on BE.
-        c = unsafe { __crc32d(c, (*d).to_le()) };
+    let last = words.len() / 3;
+    if last >= Z_BATCH_MIN {
+        let mut crc1: u32 = 0;
+        let mut crc2: u32 = 0;
+        for i in 0..last {
+            // SAFETY: requires the "crc" feature.
+            unsafe {
+                crc = __crc32d(crc, words[i].to_le());
+                crc1 = __crc32d(crc1, words[i + last].to_le());
+                crc2 = __crc32d(crc2, words[i + 2 * last].to_le());
+            }
+        }
+        words = &words[3 * last..];
+        let val = x2nmodp(last as u64, 6);
+        crc = multmodp(val, crc) ^ crc1;
+        crc = multmodp(val, crc) ^ crc2;
     }
 
-    // SAFETY: `remainder` requires the feature "crc" but so does this function
-    c = unsafe { remainder(c, after) };
+    for &w in words {
+        // SAFETY: requires the "crc" feature.
+        crc = unsafe { __crc32d(crc, w.to_le()) };
+    }
 
-    !c
+    // SAFETY: requires the "crc" feature.
+    crc = unsafe { remainder(crc, after) };
+
+    !crc
 }
 
 #[inline]

--- a/zlib-rs/src/crc32/combine.rs
+++ b/zlib-rs/src/crc32/combine.rs
@@ -23,7 +23,7 @@ const X2N_TABLE: [u32; 32] = [
 
 // Return a(x) multiplied by b(x) modulo p(x), where p(x) is the CRC polynomial,
 // reflected. For speed, this requires that a not be zero.
-const fn multmodp(a: u32, mut b: u32) -> u32 {
+pub(crate) const fn multmodp(a: u32, mut b: u32) -> u32 {
     let mut m = 1 << 31;
     let mut p = 0;
 
@@ -46,7 +46,7 @@ const fn multmodp(a: u32, mut b: u32) -> u32 {
 }
 
 // Return x^(n * 2^k) modulo p(x).
-const fn x2nmodp(mut n: u64, mut k: u32) -> u32 {
+pub(crate) const fn x2nmodp(mut n: u64, mut k: u32) -> u32 {
     let mut p: u32 = 1 << 31; /* x^0 == 1 */
 
     while n > 0 {


### PR DESCRIPTION
Provides a significant speedup on aarch64, especially on M1 and later chips.

On a mac mini we see a ~3X speedup. 

``` 
----------------------------------------------------------------------------------------------------
  CHECKSUMS
----------------------------------------------------------------------------------------------------
Benchmark                                  CPython zlib        zlib_py          Speedup
----------------------------------------------------------------------------------------------------
adler32   1 KB                                   0.1 us         0.2 us     1.33x slower
crc32     1 KB                                   0.1 us         0.3 us     2.00x slower
adler32  64 KB                                   3.7 us         2.0 us     1.80x faster
crc32    64 KB                                   2.6 us         7.7 us     2.97x slower
adler32   1 MB                                  57.0 us        30.5 us     1.87x faster
crc32     1 MB                                  28.9 us       120.0 us     4.16x slower
adler32  10 MB                                 568.8 us       302.8 us     1.88x faster
crc32    10 MB                                 285.0 us        1.20 ms     4.21x slower
```

```
----------------------------------------------------------------------------------------------------
  CHECKSUMS
----------------------------------------------------------------------------------------------------
Benchmark                                  CPython zlib        zlib_py          Speedup
----------------------------------------------------------------------------------------------------
adler32   1 KB                                   0.1 us         0.2 us     1.33x slower
crc32     1 KB                                   0.1 us         0.3 us     2.00x slower
adler32  64 KB                                   3.7 us         2.0 us     1.83x faster
crc32    64 KB                                   2.6 us         2.8 us     1.10x slower
adler32   1 MB                                  57.0 us        30.3 us     1.88x faster
crc32     1 MB                                  28.6 us        41.0 us     1.43x slower
adler32  10 MB                                 568.9 us       301.5 us     1.89x faster
crc32    10 MB                                 286.3 us       405.6 us     1.42x slower
``` 

Our crc32 implementation is still slower than cpython because apple zlib uses custom inline assembly. We'll get back to that, I already have a prototype that beats it.