### PR TITLE
crc32: add options to ARM inline asm

### DIFF
--- a/zlib-rs/src/crc32/acle.rs
+++ b/zlib-rs/src/crc32/acle.rs
@@ -71,9 +71,14 @@ mod asm {
     #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
     pub unsafe fn __crc32b(mut crc: u32, data: u8) -> u32 {
         unsafe {
-            core::arch::asm!("crc32b {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
-            crc
+            core::arch::asm!(
+                "crc32b {crc:w}, {crc:w}, {data:w}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
         }
+        crc
     }
 
     /// CRC32 single round checksum for half words (16 bits).
@@ -83,9 +88,14 @@ mod asm {
     #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
     pub unsafe fn __crc32h(mut crc: u32, data: u16) -> u32 {
         unsafe {
-            core::arch::asm!("crc32h {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
-            crc
+            core::arch::asm!(
+                "crc32h {crc:w}, {crc:w}, {data:w}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
         }
+        crc
     }
 
     /// CRC32 single round checksum for words (32 bits).
@@ -95,9 +105,14 @@ mod asm {
     #[cfg_attr(target_arch = "arm", target_feature(enable = "v8"))]
     pub unsafe fn __crc32w(mut crc: u32, data: u32) -> u32 {
         unsafe {
-            core::arch::asm!("crc32w {crc:w}, {crc:w}, {data:w}", crc = inout(reg) crc, data = in(reg) data);
-            crc
+            core::arch::asm!(
+                "crc32w {crc:w}, {crc:w}, {data:w}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
         }
+        crc
     }
 
     /// CRC32 single round checksum for double words (64 bits).
@@ -107,9 +122,14 @@ mod asm {
     #[target_feature(enable = "crc")]
     pub unsafe fn __crc32d(mut crc: u32, data: u64) -> u32 {
         unsafe {
-            core::arch::asm!("crc32x {crc:w}, {crc:w}, {data:x}", crc = inout(reg) crc, data = in(reg) data);
-            crc
+            core::arch::asm!(
+                "crc32x {crc:w}, {crc:w}, {data:x}",
+                crc = inout(reg) crc,
+                data = in(reg) data,
+                options(pure, nomem, nostack, preserves_flags)
+            );
         }
+        crc
     }
 }
 


### PR DESCRIPTION
Inline assembly can be fed hints that give the compiler more opportunities for optimization. See https://doc.rust-lang.org/reference/inline-assembly.html#options.

Seems to be some small improvement, <~1% in some rough benchmarks over large inputs, tested on M3 Max.
```
# hyperfine -N --warmup 10 --runs 100 './target/release/examples/crc32_bench_before sse 1G.bin'
Benchmark 1: ./target/release/examples/crc32_bench_before sse 1G.bin
  Time (mean ± σ):     232.0 ms ±   4.1 ms    [User: 107.8 ms, System: 123.6 ms]
  Range (min … max):   227.8 ms … 254.6 ms    100 runs

# hyperfine -N --warmup 10 --runs 100 './target/release/examples/crc32_bench sse 1G.bin'
Benchmark 1: ./target/release/examples/crc32_bench sse 1G.bin
  Time (mean ± σ):     228.7 ms ±   5.0 ms    [User: 105.3 ms, System: 122.8 ms]
  Range (min … max):   220.2 ms … 252.9 ms    100 runs
```

Analyzing the generated assembly, the biggest effects are on the reordering of `sub` instructions, and we save one load/store of the stack pointer.

This changeset is moot once the MSRV is bumped and we can use the actual compiler intrinsics.