### PR TITLE
deflate: elide dead bounds check in longest_match chain walk

### DIFF
--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -22,6 +22,9 @@ fn longest_match_help<const SLOW: bool>(
     let wmask = state.w_mask();
     let window = state.window.filled();
     let scan = &window[strstart..];
+
+    // Elide bounds checks in the loop.
+    let prev = &state.prev.as_slice()[..=wmask];
     let mut limit: Pos;
     let limit_base: Pos;
     let early_exit: bool;
@@ -36,7 +39,7 @@ fn longest_match_help<const SLOW: bool>(
         () => {
             chain_length -= 1;
             if chain_length > 0 {
-                cur_match = state.prev.as_slice()[cur_match as usize & wmask];
+                cur_match = prev[cur_match as usize & wmask];
 
                 if cur_match > limit {
                     continue;
@@ -286,7 +289,7 @@ fn longest_match_help<const SLOW: bool>(
                 let mut next_pos = cur_match;
 
                 for i in 0..=len - STD_MIN_MATCH {
-                    pos = state.prev.as_slice()[(cur_match as usize + i) & wmask];
+                    pos = prev[(cur_match as usize + i) & wmask];
                     if pos < next_pos {
                         /* Hash chain is more distant, use it */
                         if pos <= limit_base + i as Pos {


### PR DESCRIPTION
## Summary

In `longest_match` — the hottest loop in deflate — the hash-chain walk reads
`prev[cur_match & wmask]` on every step. `prev` has length `w_size` and
`wmask == w_size - 1`, so the index is always in bounds, but the optimizer
can't prove `wmask + 1 == prev.len()` and so emits a bounds check on every
chain link.

Re-slicing `prev` to `[..=wmask]` once at function entry makes the length
relationship visible, and the optimizer drops the check from all three
chain-walk variants. The single remaining check (the re-slice) runs once per
call instead of once per chain link.

A small step toward #18: it trims instruction count in the hottest deflate
loop, where zlib-rs still trails zlib-ng on x86_64.

## Generated code

aarch64, `-Ctarget-cpu=native`, the per-link chain step.

**Before:**

```asm
sub  w27, w27, #0x1          ; chain_length -= 1
tst  w27, #0xffff
b.eq <return>                ; chain exhausted
and  x8, x24, x10            ; idx = cur_match & wmask
cmp  x8, x22                 ; idx >= prev.len() ?
b.hs <panic_bounds_check>    ; <-- removed
ldrh w19, [x28, x8, lsl #1]  ; cur_match = prev[idx]
cmp  w19, w23, uxth          ; cur_match > limit ?
b.hi <loop>
```

**After:**

```asm
sub  w26, w26, #0x1          ; chain_length -= 1
tst  w26, #0xffff
b.eq <return>                ; chain exhausted
and  x8, x22, x10            ; idx = cur_match & wmask
ldrh w28, [x27, x8, lsl #1]  ; cur_match = prev[idx]
cmp  w28, w23, uxth          ; cur_match > limit ?
b.hi <loop>
```

(Register numbers differ because removing the check shifts register
allocation.) The `cmp` + `b.hs panic_bounds_check` pair is gone. Counting the
bounds/index-fail call sites in `longest_match` drops from **8 to 6**: three
hot per-link checks removed, one hoisted re-slice check added.

## Verification

- Output byte-identical — all `zlib-rs` unit tests and the `test-libz-rs-sys`
  zlib-ng cross-validation tests (`compress_lcet10`, `compress_paper_100k` /
  `compress_fireworks` over levels 0–9) pass.

## Note on wall-clock

On an Apple M2 (aarch64) this does **not** change wall-clock: that loop is
memory-latency-bound on the hash-chain pointer chase and the removed branch
was perfectly predicted. It's purely an instruction-count reduction, which
should show on x86_64's `perf instructions`. No measurable wall-clock
regression at any level.

Generated by Claude Opus