### PR TITLE
deflate: avoid bounds-checked re-slices in longest_match; const-length bit-buffer flush

### DIFF
--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -4294,6 +4294,26 @@ mod test {
         fuzz_based_test(&input, config, &expected);
     }
 
+    #[test]
+    fn send_bits_full_buffer() {
+        // Exercise the `bits_used == BIT_BUF_SIZE` branch in `send_bits_overflow`:
+        // when the bit buffer is exactly full (64 bits), the buffered bits must be
+        // flushed before the new value is placed into a fresh buffer.
+        let mut buf = [MaybeUninit::<u8>::uninit(); 32];
+        let pending = unsafe { Pending::from_raw_parts(buf.as_mut_ptr(), buf.len()) };
+        let mut bw = BitWriter::from_pending(pending);
+
+        bw.bit_buffer = 0x0807060504030201_u64;
+        bw.bits_used = BitWriter::BIT_BUF_SIZE; // exactly 64 — buffer is full
+
+        bw.send_bits(0b101, 3);
+
+        // The full 64-bit buffer was flushed as 8 LE bytes; the 3 new bits start fresh.
+        assert_eq!(bw.pending.pending(), &0x0807060504030201_u64.to_le_bytes());
+        assert_eq!(bw.bit_buffer, 0b101);
+        assert_eq!(bw.bits_used, 3);
+    }
+
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     mod _cache_lines {
         use super::State;

--- a/zlib-rs/src/deflate.rs
+++ b/zlib-rs/src/deflate.rs
@@ -1047,12 +1047,12 @@ impl<'a> BitWriter<'a> {
 
     fn send_bits_overflow(&mut self, val: u64, total_bits: u8) {
         if self.bits_used == Self::BIT_BUF_SIZE {
-            self.pending.extend(&self.bit_buffer.to_le_bytes());
+            self.pending.extend_const(&self.bit_buffer.to_le_bytes());
             self.bit_buffer = val;
             self.bits_used = total_bits - Self::BIT_BUF_SIZE;
         } else {
             self.bit_buffer |= val << self.bits_used;
-            self.pending.extend(&self.bit_buffer.to_le_bytes());
+            self.pending.extend_const(&self.bit_buffer.to_le_bytes());
             self.bit_buffer = val >> (Self::BIT_BUF_SIZE - self.bits_used);
             self.bits_used = total_bits - Self::BIT_BUF_SIZE;
         }

--- a/zlib-rs/src/deflate/longest_match.rs
+++ b/zlib-rs/src/deflate/longest_match.rs
@@ -70,7 +70,7 @@ fn longest_match_help<const SLOW: bool>(
     }
 
     let mut mbase_start = window.as_ptr();
-    let mut mbase_end = window[offset..].as_ptr();
+    let mut mbase_end = mbase_start.wrapping_add(offset);
 
     // Don't waste too much time by following a chain if we already have a good match
     chain_length = state.max_chain_length;
@@ -130,8 +130,8 @@ fn longest_match_help<const SLOW: bool>(
         early_exit = state.level < EARLY_EXIT_TRIGGER_LEVEL;
     }
 
-    let scan_start = window[strstart..].as_ptr();
-    let mut scan_end = window[strstart + offset..].as_ptr();
+    let scan_start = scan.as_ptr();
+    let mut scan_end = scan_start.wrapping_add(offset);
 
     assert!(
         strstart <= state.window_size.saturating_sub(MIN_LOOKAHEAD),

--- a/zlib-rs/src/deflate/pending.rs
+++ b/zlib-rs/src/deflate/pending.rs
@@ -77,6 +77,24 @@ impl<'a> Pending<'a> {
         self.pending += buf.len();
     }
 
+    /// Like [`extend`](Self::extend), but for a fixed-size array.
+    ///
+    /// Because the length is a compile-time constant, the optimizer collapses the
+    /// capacity check and the slice-index bounds check (which are mathematically
+    /// identical: `out + pending + N <= buf.len()`) into a single comparison, and
+    /// emits the copy as one fixed-width store.
+    #[inline(always)]
+    #[track_caller]
+    pub fn extend_const<const N: usize>(&mut self, buf: &[u8; N]) {
+        // SAFETY: [u8; N] is valid [MaybeUninit<u8>; N]
+        let buf = unsafe { &*(buf as *const [u8; N] as *const [MaybeUninit<u8>; N]) };
+
+        let start = self.out + self.pending;
+        self.buf.as_mut_slice()[start..][..N].copy_from_slice(buf);
+
+        self.pending += N;
+    }
+
     pub(crate) unsafe fn from_raw_parts(ptr: *mut MaybeUninit<u8>, len: usize) -> Self {
         let buf = unsafe { WeakSliceMut::from_raw_parts_mut(ptr, len) };
 


### PR DESCRIPTION
Two small, byte-identical reductions in the deflate hot path (towards #18).

### 1. `longest_match`: avoid bounds-checked window re-slices
`mbase_end`/`scan_start`/`scan_end` were built with `window[..].as_ptr()`, which forms a
bounds-checked sub-slice only to discard the slice and keep its pointer. The offsets are
always in bounds (`offset <= STD_MAX_MATCH - 7`, `strstart <= window_size - MIN_LOOKAHEAD`),
so these are replaced with the equivalent `wrapping_add`. The two `cmp`/`ja
<slice_index_fail>` pairs and their landing pads are gone (before/after disassembly in the
commit message).

### 2. `Pending::extend_const::<8>` for the bit-buffer flush
`send_bits_overflow` flushed the 8-byte bit buffer via `extend(&[u8])`, whose runtime length
made the capacity assert and the slice-index bound two separate comparisons. A const-length
`extend_const` folds the slice bound into the subtraction that computes `remaining()`,
removing one `cmp` per flush arm.

### Verification
- Output is **byte-identical** to the previous code at all 10 levels (and matches zlib-ng).
- Full unit + zlib-ng cross-validation suite passes (369 tests); `cargo fmt` clean; no new clippy warnings.
- callgrind instruction count: commit 1 — L2 −1.6%, L4 −1.1%, L6 −0.9%, L9 −1.0%; commit 2 — L1 −0.19%.

### Note on wall-time
These reduce the deterministic instruction-count metric but on a high-IPC core the change is within the wall-time noise floor — no wall-time speedup is claimed.

Generated by Claude Code Opus 4.8 Ultracode