### PR TITLE
Improve the LoongArch CRC32 implementation based on the AArch64 one

### DIFF
--- a/zlib-rs/src/crc32/loongarch.rs
+++ b/zlib-rs/src/crc32/loongarch.rs
@@ -1,22 +1,59 @@
+use super::combine::{multmodp, x2nmodp};
+
+// The constants here are taken from the AArch64 implementation.
+// Playing around with them showed no gains from larger batches,
+// but losses from smaller ones. No reason to deviate here.
+const Z_BATCH: usize = 3990;
+const Z_BATCH_ZEROS: u32 = x2nmodp(Z_BATCH as u64, 6);
+const _: () = assert!(Z_BATCH_ZEROS == 0xa10d3d0c);
+const Z_BATCH_MIN: usize = 800;
+
+/// 2-way interleaved CRC32, inspired by the AArch64 implementation.
+///
+/// Runs two independent crc32 streams simultaneously to exploit the
+/// ~2-cycle throughput of the instruction, then combines them with
+/// polynomial multiplication.
+///
+/// Throughput was measured around 1.995 on a Loongson 3B6000.
 pub fn crc32_loongarch64(crc: u32, buf: &[u8]) -> u32 {
-    let mut c = !crc as i32;
+    let mut crc = !crc as i32;
 
     // SAFETY: [u8; 8] safely transmutes into i64.
     let (before, middle, after) = unsafe { buf.align_to::<i64>() };
 
-    c = remainder(c, before);
+    crc = remainder(crc, before);
 
-    if middle.is_empty() && after.is_empty() {
-        return !c as u32;
+    let mut words = middle;
+
+    while words.len() >= 2 * Z_BATCH {
+        let mut crc1: i32 = 0;
+        for i in 0..Z_BATCH {
+            crc = crc_w_d_w(words[i].to_le(), crc);
+            crc1 = crc_w_d_w(words[i + Z_BATCH].to_le(), crc1);
+        }
+        words = &words[2 * Z_BATCH..];
+        crc = multmodp(Z_BATCH_ZEROS, crc as u32) as i32 ^ crc1;
     }
 
-    for d in middle {
-        c = crc_w_d_w(*d, c);
+    let last = words.len() / 2;
+    if last >= Z_BATCH_MIN {
+        let mut crc1: i32 = 0;
+        for i in 0..last {
+            crc = crc_w_d_w(words[i].to_le(), crc);
+            crc1 = crc_w_d_w(words[i + last].to_le(), crc1);
+        }
+        words = &words[2 * last..];
+        let val = x2nmodp(last as u64, 6);
+        crc = multmodp(val, crc as u32) as i32 ^ crc1;
     }
 
-    c = remainder(c, after);
+    for &w in words {
+        crc = crc_w_d_w(w.to_le(), crc);
+    }
 
-    !c as u32
+    crc = remainder(crc, after);
+
+    !crc as u32
 }
 
 #[inline]


### PR DESCRIPTION
This ports the stock zlib AArch64 CRC32 implementation over to LoongArch, but accounts for the throughput of 2 rather than 3.

Gains from the sse benchmark show around 10% wall time gain on 1GB input, which is in line with the 15% gain I saw on AArch64. This apparently scales linearly with the instruction throughput.