### PR TITLE
crc32/loongarch: CRC intrinsics are stabilized in 1.98

### DIFF
--- a/zlib-rs/src/crc32/loongarch.rs
+++ b/zlib-rs/src/crc32/loongarch.rs
@@ -87,8 +87,8 @@ crate::cfg_select! {
     }
 }
 
-// FIXME: there are intrinsics for these in the standard library, but currently
-// unstable behind the stdarch_loongarch feature
+// FIXME: the intrinsics below are stable since Rust 1.98.0, remove them and
+// use the standard library versions once our MSRV reaches that version
 //
 // CRC32 instructions are part of the basic integer operations and therefore
 // always available.

--- a/zlib-rs/src/lib.rs
+++ b/zlib-rs/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = core::include_str!("../README.md")]
 #![cfg_attr(not(any(test, feature = "rust-allocator")), no_std)]
-// For testing the loongarch64 crc32 implementation.
-#![cfg_attr(all(miri, target_arch = "loongarch64"), feature(stdarch_loongarch))]
 
 #[cfg(any(feature = "rust-allocator", feature = "c-allocator"))]
 extern crate alloc;


### PR DESCRIPTION
We therefore don't need to set feature(stdarch_loongarch) for Miri anymore, since Miri always runs on nightly where it's now stable.