### PR TITLE
Add LSX-autovectorized slide hash

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -85,9 +85,11 @@ jobs:
             codecov: false
             packages: gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu qemu-user qemu-user-static
 
-          - target: "loongarch64-unknown-linux-gnu"
+          - rust: nightly
+            target: "loongarch64-unknown-linux-gnu"
             os: ubuntu-26.04
             codecov: false
+            flags: "--features=lsx"
             packages: gcc-loongarch64-linux-gnu g++-loongarch64-linux-gnu qemu-user qemu-user-binfmt
 
           - target: "wasm32-wasip1"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -76,14 +76,14 @@ jobs:
             packages: gcc-i686-linux-gnu g++-i686-linux-gnu
 
           - target: "s390x-unknown-linux-gnu"
-            os: ubuntu-latest
+            os: ubuntu-26.04
             codecov: false
-            packages: gcc-s390x-linux-gnu g++-s390x-linux-gnu qemu-user qemu-user-static
+            packages: gcc-s390x-linux-gnu g++-s390x-linux-gnu qemu-user qemu-user-binfmt
 
           - target: "powerpc64le-unknown-linux-gnu"
-            os: ubuntu-latest
+            os: ubuntu-26.04
             codecov: false
-            packages: gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu qemu-user qemu-user-static
+            packages: gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu qemu-user qemu-user-binfmt
 
           - rust: nightly
             target: "loongarch64-unknown-linux-gnu"

--- a/zlib-rs/Cargo.toml
+++ b/zlib-rs/Cargo.toml
@@ -27,6 +27,7 @@ __internal-api = [] # export internal symbols for use in `libz-rs-sys`.
 ZLIB_DEBUG = []
 vpclmulqdq = [] # use avx512 to speed up crc32. Only stable from 1.89.0 onwards.
 avx512 = ["vpclmulqdq"] # use avx512 to speed up crc32 and adler32. Only stable from 1.89.0 onwards.
+lsx = [] # use LSX to speed up various parts of zlib-rs. Feature stabilized in 1.89.0, intrinsics are unstable.
 
 
 [dependencies]

--- a/zlib-rs/src/cpu_features.rs
+++ b/zlib-rs/src/cpu_features.rs
@@ -101,6 +101,16 @@ pub fn is_enabled_crc() -> bool {
     false
 }
 
+// FIXME: Remove lsx feature guard once MSRV is 1.89.0 or higher
+#[inline(always)]
+pub fn is_enabled_lsx() -> bool {
+    #[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+    #[cfg(feature = "std")]
+    return std::arch::is_loongarch_feature_detected!("lsx");
+
+    false
+}
+
 #[inline(always)]
 pub fn is_enabled_simd128() -> bool {
     #[cfg(target_arch = "wasm32")]

--- a/zlib-rs/src/deflate/slide_hash.rs
+++ b/zlib-rs/src/deflate/slide_hash.rs
@@ -20,6 +20,12 @@ fn slide_hash_chain(table: &mut [u16], wsize: u16) {
         return unsafe { neon::slide_hash_chain(table, wsize) };
     }
 
+    // FIXME: Remove lsx feature guard once MSRV is 1.89.0 or higher
+    #[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+    if crate::cpu_features::is_enabled_lsx() {
+        return unsafe { lsx::slide_hash_chain(table, wsize) };
+    }
+
     #[cfg(target_arch = "wasm32")]
     if crate::cpu_features::is_enabled_simd128() {
         // SAFETY: the simd128 target feature is enabled.
@@ -74,6 +80,20 @@ mod neon {
     pub unsafe fn slide_hash_chain(table: &mut [u16], wsize: u16) {
         // 32 means that 4 128-bit values can be processed per iteration. That appear to be the
         // optimal amount for neon.
+        super::generic_slide_hash_chain::<32>(table, wsize);
+    }
+}
+
+// FIXME: Remove lsx feature guard once MSRV is 1.89.0 or higher
+#[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+mod lsx {
+    /// # Safety
+    ///
+    /// Behavior is undefined if the `lsx` target feature is not enabled.
+    #[target_feature(enable = "lsx")]
+    pub unsafe fn slide_hash_chain(table: &mut [u16], wsize: u16) {
+        // 32 means that 4 128-bit values can be processed per iteration. That appear to be the
+        // optimal amount for LSX.
         super::generic_slide_hash_chain::<32>(table, wsize);
     }
 }
@@ -138,6 +158,19 @@ mod tests {
             let mut input = INPUT;
 
             unsafe { neon::slide_hash_chain(&mut input, WSIZE) };
+
+            assert_eq!(input, OUTPUT);
+        }
+    }
+
+    // FIXME: Remove lsx feature guard once MSRV is 1.89.0 or higher
+    #[test]
+    #[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+    fn test_slide_hash_lsx() {
+        if crate::cpu_features::is_enabled_lsx() {
+            let mut input = INPUT;
+
+            unsafe { lsx::slide_hash_chain(&mut input, WSIZE) };
 
             assert_eq!(input, OUTPUT);
         }


### PR DESCRIPTION
See https://godbolt.org/z/jhrGxPn87. In practice, both loongarch64-unknown-linux-gnu and loongarch64-unknown-linux-musl include LSX in their target baseline (though it isn't required by the ISA), so the feature detection is usually optimized away.