### PR TITLE
add `{compress, uncompress, etc.}_z` variants that take `usize` for lengths

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -531,6 +531,7 @@ jobs:
           objdump -T target/${{matrix.target}}/release/libz_rs.versioned.so | grep "ZLIB"
           objdump -T target/${{matrix.target}}/release/libz_rs.versioned.so | grep -q -E "ZLIB_1\.2\.2\.3.*deflateTune" || (echo "symbol not found!" && exit 1)
           objdump -T target/${{matrix.target}}/release/libz_rs.versioned.so | grep -q -E "ZLIB_1\.3\.1\.2.*deflateUsed" || (echo "symbol not found!" && exit 1)
+          objdump -T target/${{matrix.target}}/release/libz_rs.versioned.so | grep -q -E "ZLIB_1\.3\.2.*uncompress_z" || (echo "symbol not found!" && exit 1)
 
       - name: ABI comparison vs zlib-ng
         working-directory: libz-rs-sys-cdylib

--- a/libz-rs-sys/include/zlib.map
+++ b/libz-rs-sys/include/zlib.map
@@ -101,3 +101,15 @@ ZLIB_1.2.12 {
 ZLIB_1.3.1.2 {
 	deflateUsed;
 } ZLIB_1.2.12;
+
+ZLIB_1.3.2 {
+  global:
+    compressBound_z;
+	deflateBound_z;
+	compress_z;
+	compress2_z;
+	uncompress_z;
+	uncompress2_z;
+  local:
+    inflate_fixed;
+} ZLIB_1.3.1.2;

--- a/libz-rs-sys/src/lib.rs
+++ b/libz-rs-sys/src/lib.rs
@@ -421,6 +421,25 @@ pub extern "C" fn adler32_combine64(adler1: c_ulong, adler2: c_ulong, len2: z_of
     }
 }
 
+/// Like [`uncompress`] but takes a `usize` instead.
+///
+/// # Returns
+///
+/// Same as [`uncompress`].
+///
+/// # Safety
+///
+/// Same as [`uncompress`].
+#[cfg_attr(feature = "export-symbols", export_name = prefix!(uncompress_z))]
+pub unsafe extern "C" fn uncompress_z(
+    dest: *mut u8,
+    destLen: *mut usize,
+    source: *const u8,
+    mut sourceLen: usize,
+) -> c_int {
+    uncompress2_z(dest, destLen, source, &mut sourceLen)
+}
+
 /// Inflates `source` into `dest`, and writes the final inflated size into `destLen`.
 ///
 /// Upon entry, `destLen` is the total size of the destination buffer, which must be large enough to hold the entire
@@ -486,6 +505,49 @@ pub unsafe extern "C" fn uncompress(
     uncompress2(dest, destLen, source, &mut sourceLen)
 }
 
+/// Like [`uncompress2`] but takes a `usize` instead.
+///
+/// # Returns
+///
+/// Same as [`uncompress2`].
+///
+/// # Safety
+///
+/// Same as [`uncompress2`].
+#[cfg_attr(feature = "export-symbols", export_name = prefix!(uncompress2_z))]
+pub unsafe extern "C" fn uncompress2_z(
+    dest: *mut u8,
+    destLen: *mut usize,
+    source: *const u8,
+    sourceLen: *mut usize,
+) -> c_int {
+    // stock zlib will just dereference a NULL pointer: that's UB.
+    // Hence us returning an error value is compatible
+    let Some(destLen) = (unsafe { destLen.as_mut() }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let Some(sourceLen) = (unsafe { sourceLen.as_mut() }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let Some(output) = (unsafe { slice_from_raw_parts_uninit_mut(dest, *destLen) }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let Some(input) = (unsafe { slice_from_raw_parts(source, *sourceLen) }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let config = InflateConfig::default();
+    let (consumed, output, err) = zlib_rs::inflate::uncompress2(output, input, config);
+
+    *sourceLen -= consumed as usize;
+    *destLen = output.len();
+
+    err as c_int
+}
+
 /// Inflates `source` into `dest` like [`uncompress`], and writes the final inflated size into `destLen` and the number
 /// of source bytes consumed into `sourceLen`.
 ///
@@ -534,19 +596,13 @@ pub unsafe extern "C" fn uncompress2(
         return ReturnCode::StreamError as _;
     };
 
-    let Some(output) = (unsafe { slice_from_raw_parts_uninit_mut(dest, *destLen as usize) }) else {
-        return ReturnCode::StreamError as _;
-    };
+    let mut got = *destLen as usize;
+    let mut used = *sourceLen as usize;
 
-    let Some(input) = (unsafe { slice_from_raw_parts(source, *sourceLen as usize) }) else {
-        return ReturnCode::StreamError as _;
-    };
+    let err = uncompress2_z(dest, &mut got, source, &mut used);
 
-    let config = InflateConfig::default();
-    let (consumed, output, err) = zlib_rs::inflate::uncompress2(output, input, config);
-
-    *sourceLen -= consumed as c_ulong;
-    *destLen = output.len() as c_ulong;
+    *sourceLen = used as c_ulong;
+    *destLen = got as c_ulong;
 
     err as c_int
 }
@@ -1285,9 +1341,54 @@ pub unsafe extern "C" fn deflateSetHeader(strm: *mut z_stream, head: gz_headerp)
 /// * Either
 ///     - `strm` is `NULL`
 ///     - `strm` satisfies the requirements of `&mut *strm` and was initialized with [`deflateInit_`] or similar
+#[cfg_attr(feature = "export-symbols", export_name = prefix!(deflateBound_z))]
+pub unsafe extern "C" fn deflateBound_z(strm: *mut z_stream, sourceLen: usize) -> usize {
+    zlib_rs::deflate::bound(DeflateStream::from_stream_mut(strm), sourceLen)
+}
+
+/// Returns an upper bound on the compressed size after deflation of `sourceLen` bytes.
+///
+/// This function must be called after [`deflateInit_`] or [`deflateInit2_`].
+/// This would be used to allocate an output buffer for deflation in a single pass, and so would be called before [`deflate`].
+/// If that first [`deflate`] call is provided the `sourceLen` input bytes, an output buffer allocated to the size returned by [`deflateBound`],
+/// and the flush value [`Z_FINISH`], then [`deflate`] is guaranteed to return [`Z_STREAM_END`].
+///
+/// Note that it is possible for the compressed size to be larger than the value returned by [`deflateBound`]
+/// if flush options other than [`Z_FINISH`] or [`Z_NO_FLUSH`] are used.
+///
+/// ## Safety
+///
+/// * Either
+///     - `strm` is `NULL`
+///     - `strm` satisfies the requirements of `&mut *strm` and was initialized with [`deflateInit_`] or similar
 #[cfg_attr(feature = "export-symbols", export_name = prefix!(deflateBound))]
 pub unsafe extern "C" fn deflateBound(strm: *mut z_stream, sourceLen: c_ulong) -> c_ulong {
     zlib_rs::deflate::bound(DeflateStream::from_stream_mut(strm), sourceLen as usize) as c_ulong
+}
+
+/// Like [`compress`] but takes a `usize` instead.
+///
+/// # Returns
+///
+/// Same as [`compress`].
+///
+/// # Safety
+///
+/// Same as [`compress`].
+#[cfg_attr(feature = "export-symbols", export_name = prefix!(compress_z))]
+pub unsafe extern "C" fn compress_z(
+    dest: *mut Bytef,
+    destLen: *mut usize,
+    source: *const Bytef,
+    sourceLen: usize,
+) -> c_int {
+    compress2_z(
+        dest,
+        destLen,
+        source,
+        sourceLen,
+        DeflateConfig::default().level,
+    )
 }
 
 /// Compresses `source` into `dest`, and writes the final deflated size into `destLen`.
@@ -1358,6 +1459,45 @@ pub unsafe extern "C" fn compress(
     )
 }
 
+/// Like [`compress2`] but takes a `usize` instead.
+///
+/// # Returns
+///
+/// Same as [`compress2`].
+///
+/// # Safety
+///
+/// Same as [`compress2`].
+#[cfg_attr(feature = "export-symbols", export_name = prefix!(compress2_z))]
+pub unsafe extern "C" fn compress2_z(
+    dest: *mut Bytef,
+    destLen: *mut usize,
+    source: *const Bytef,
+    sourceLen: usize,
+    level: c_int,
+) -> c_int {
+    // stock zlib will just dereference a NULL pointer: that's UB.
+    // Hence us returning an error value is compatible
+    let Some(destLen) = (unsafe { destLen.as_mut() }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let Some(output) = (unsafe { slice_from_raw_parts_uninit_mut(dest, *destLen) }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let Some(input) = (unsafe { slice_from_raw_parts(source, sourceLen) }) else {
+        return ReturnCode::StreamError as _;
+    };
+
+    let config = DeflateConfig::new(level);
+    let (output, err) = zlib_rs::deflate::compress(output, input, config);
+
+    *destLen = output.len();
+
+    err as c_int
+}
+
 /// Compresses `source` into `dest`, and writes the final deflated size into `destLen`.
 ///
 /// The level parameter has the same meaning as in [`deflateInit_`].
@@ -1399,20 +1539,19 @@ pub unsafe extern "C" fn compress2(
         return ReturnCode::StreamError as _;
     };
 
-    let Some(output) = (unsafe { slice_from_raw_parts_uninit_mut(dest, *destLen as usize) }) else {
-        return ReturnCode::StreamError as _;
-    };
+    let mut got = *destLen as usize;
+    let ret = compress2_z(dest, &mut got, source, sourceLen as usize, level);
+    *destLen = got as c_ulong;
 
-    let Some(input) = (unsafe { slice_from_raw_parts(source, sourceLen as usize) }) else {
-        return ReturnCode::StreamError as _;
-    };
+    ret
+}
 
-    let config = DeflateConfig::new(level);
-    let (output, err) = zlib_rs::deflate::compress(output, input, config);
-
-    *destLen = output.len() as c_ulong;
-
-    err as c_int
+/// Returns an upper bound on the compressed size after [`compress`] or [`compress2`] on `sourceLen` bytes.
+///
+/// Can be used before a [`compress`] or [`compress2`] call to allocate the destination buffer.
+#[cfg_attr(feature = "export-symbols", export_name = prefix!(compressBound_z))]
+pub extern "C" fn compressBound_z(sourceLen: usize) -> usize {
+    zlib_rs::deflate::compress_bound(sourceLen)
 }
 
 /// Returns an upper bound on the compressed size after [`compress`] or [`compress2`] on `sourceLen` bytes.

--- a/test-libz-rs-sys/src/deflate.rs
+++ b/test-libz-rs-sys/src/deflate.rs
@@ -768,13 +768,13 @@ fn deflate_bound_gzip_header_basic() {
     ignore = "we don't support DFLTCC, which changes the bounds in zlib-ng"
 )]
 fn test_compress_bound_windows() {
-    let source_len = 4294967289 as core::ffi::c_ulong;
+    let source_len = (u32::MAX - 6) as core::ffi::c_ulong;
 
     assert_eq_rs_ng!({ compressBound(source_len as _) });
 
     assert_eq!(
-        libz_rs_sys::compressBound(source_len as _) as usize,
-        libz_rs_sys::compressBound_z(source_len as _)
+        libz_rs_sys::compressBound(source_len as _),
+        libz_rs_sys::compressBound_z(source_len as _) as c_ulong,
     );
 }
 
@@ -790,8 +790,8 @@ fn test_compress_bound() {
         assert_eq_rs_ng!({ compressBound(source_len as _) });
 
         assert_eq!(
-            libz_rs_sys::compressBound(source_len as _) as usize,
-            libz_rs_sys::compressBound_z(source_len as _)
+            libz_rs_sys::compressBound(source_len as _),
+            libz_rs_sys::compressBound_z(source_len as _) as c_ulong,
         );
 
         true
@@ -976,8 +976,6 @@ fn test_deflate_prime() {
 
         err = libz_rs_sys::deflate(strm, DeflateFlush::Finish as i32);
         assert_eq!(err, ReturnCode::StreamEnd as i32);
-
-        dbg!(strm.total_out);
 
         /* Gzip uncompressed data crc32 */
         let crc = libz_rs_sys::crc32(0, HELLO.as_ptr(), HELLO.len() as _);

--- a/test-libz-rs-sys/src/deflate.rs
+++ b/test-libz-rs-sys/src/deflate.rs
@@ -771,6 +771,11 @@ fn test_compress_bound_windows() {
     let source_len = 4294967289 as core::ffi::c_ulong;
 
     assert_eq_rs_ng!({ compressBound(source_len as _) });
+
+    assert_eq!(
+        libz_rs_sys::compressBound(source_len as _) as usize,
+        libz_rs_sys::compressBound_z(source_len as _)
+    );
 }
 
 #[test]
@@ -783,6 +788,11 @@ fn test_compress_bound() {
 
     fn test(source_len: core::ffi::c_ulong) -> bool {
         assert_eq_rs_ng!({ compressBound(source_len as _) });
+
+        assert_eq!(
+            libz_rs_sys::compressBound(source_len as _) as usize,
+            libz_rs_sys::compressBound_z(source_len as _)
+        );
 
         true
     }

--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -1093,6 +1093,118 @@ fn copy_direct_from_next_in_to_next_out() {
     });
 }
 
+/// Unit tests for the _z variants of (un)compress(2).
+#[test]
+fn compress_uncompress_z() {
+    use libz_rs_sys::{compress, compress_z, uncompress, uncompress_z};
+
+    let source = b"there is no horizon";
+
+    let mut compr_z = vec![0u8; 128];
+    let mut compr_z_len = compr_z.len();
+
+    let mut compr = vec![0u8; 128];
+    let mut compr_len = compr.len() as c_ulong;
+
+    unsafe {
+        assert_eq!(
+            compress_z(
+                compr_z.as_mut_ptr(),
+                &mut compr_z_len,
+                source.as_ptr(),
+                source.len(),
+            ),
+            Z_OK,
+        );
+        assert_eq!(
+            compress(
+                compr.as_mut_ptr(),
+                &mut compr_len,
+                source.as_ptr(),
+                source.len() as c_ulong,
+            ),
+            Z_OK,
+        );
+    }
+
+    assert_eq!(compr_z_len, compr_len as usize);
+    assert_eq!(&compr_z[..compr_z_len], &compr[..compr_len as usize]);
+
+    let mut compr2_z = vec![0u8; 128];
+    let mut compr2_z_len = compr2_z.len();
+
+    let mut compr2 = vec![0u8; 128];
+    let mut compr2_len = compr2.len() as c_ulong;
+
+    unsafe {
+        assert_eq!(
+            libz_rs_sys::compress2_z(
+                compr2_z.as_mut_ptr(),
+                &mut compr2_z_len,
+                source.as_ptr(),
+                source.len(),
+                9,
+            ),
+            Z_OK,
+        );
+        assert_eq!(
+            libz_rs_sys::compress2(
+                compr2.as_mut_ptr(),
+                &mut compr2_len,
+                source.as_ptr(),
+                source.len() as c_ulong,
+                9,
+            ),
+            Z_OK,
+        );
+    }
+
+    assert_eq!(compr2_z_len, compr2_len as usize);
+    assert_eq!(&compr2_z[..compr2_z_len], &compr2[..compr2_len as usize]);
+
+    let mut dest_z = vec![0u8; source.len()];
+    let mut dest_z_len = dest_z.len();
+
+    let mut dest = vec![0u8; source.len()];
+    let mut dest_len = dest.len() as c_ulong;
+
+    unsafe {
+        assert_eq!(
+            uncompress_z(
+                dest_z.as_mut_ptr(),
+                &mut dest_z_len,
+                compr_z.as_ptr(),
+                compr_z_len,
+            ),
+            Z_OK,
+        );
+        assert_eq!(
+            uncompress(dest.as_mut_ptr(), &mut dest_len, compr.as_ptr(), compr_len),
+            Z_OK,
+        );
+
+        let mut dest2 = vec![0u8; source.len()];
+        let mut dest2_len = dest2.len();
+        let mut source2_len = compr_z_len;
+        assert_eq!(
+            libz_rs_sys::uncompress2_z(
+                dest2.as_mut_ptr(),
+                &mut dest2_len,
+                compr_z.as_ptr(),
+                &mut source2_len,
+            ),
+            Z_OK,
+        );
+
+        assert_eq!(source2_len, compr_z_len);
+        assert_eq!(&dest2[..dest2_len], source);
+    }
+
+    assert_eq!(dest_z_len, dest_len as usize);
+    assert_eq!(&dest_z[..dest_z_len], source);
+    assert_eq!(&dest[..dest_len as usize], source);
+}
+
 #[test]
 fn hello_world_fixed() {
     // "Hello World!" compressed with `minideflate -k -f -9`

--- a/test-libz-rs-sys/src/lib.rs
+++ b/test-libz-rs-sys/src/lib.rs
@@ -912,6 +912,13 @@ mod null {
     )]
     fn deflate_bound() {
         assert_eq_rs_ng!({ deflateBound(core::ptr::null_mut(), 1024) });
+
+        unsafe {
+            assert_eq!(
+                libz_rs_sys::deflateBound(core::ptr::null_mut(), 1024) as usize,
+                libz_rs_sys::deflateBound_z(core::ptr::null_mut(), 1024),
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
These symbols are part of zlib `1.3.2`