### PR TITLE
fix unsound return lifetime on Weak*Mut::as_mut_slice()

### DIFF
--- a/zlib-rs/src/deflate/hash_calc.rs
+++ b/zlib-rs/src/deflate/hash_calc.rs
@@ -50,7 +50,8 @@ impl StandardHashCalc {
 
         let head = state.head.as_slice()[hm];
         if head != string as u16 {
-            state.prev.as_mut_slice()[string & state.w_mask()] = head;
+            let w_mask = state.w_mask();
+            state.prev.as_mut_slice()[string & w_mask] = head;
             state.head.as_mut_slice()[hm] = string as u16;
         }
 
@@ -107,7 +108,8 @@ impl RollHashCalc {
 
         let head = state.head.as_slice()[hm];
         if head != string as u16 {
-            state.prev.as_mut_slice()[string & state.w_mask()] = head;
+            let w_mask = state.w_mask();
+            state.prev.as_mut_slice()[string & w_mask] = head;
             state.head.as_mut_slice()[hm] = string as u16;
         }
 

--- a/zlib-rs/src/weak_slice.rs
+++ b/zlib-rs/src/weak_slice.rs
@@ -34,7 +34,7 @@ impl<'a, T> WeakSliceMut<'a, T> {
         unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
     }
 
-    pub(crate) fn as_mut_slice(&mut self) -> &'a mut [T] {
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe { core::slice::from_raw_parts_mut(self.ptr, self.len) }
     }
 
@@ -85,7 +85,7 @@ impl<'a, T, const N: usize> WeakArrayMut<'a, T, N> {
         unsafe { core::slice::from_raw_parts(self.ptr.cast(), N) }
     }
 
-    pub(crate) fn as_mut_slice(&mut self) -> &'a mut [T] {
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe { core::slice::from_raw_parts_mut(self.ptr.cast(), N) }
     }
 


### PR DESCRIPTION
This returns a mutable borrow while relinquishing mutable access to the source type. This is prone to lifetime extension bugs, but it's internal so it doesn't actually matter.

Worth fixing anyway.


(This issue was discovered by an audit performed using Gemini)