### PR TITLE
inflate: Use wider loads/stores with LSX

### DIFF
--- a/zlib-rs/src/inflate/writer.rs
+++ b/zlib-rs/src/inflate/writer.rs
@@ -146,6 +146,11 @@ impl<'a> Writer<'a> {
             return self.extend_from_window_help::<16>(window, range);
         }
 
+        #[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+        if crate::cpu_features::is_enabled_lsx() {
+            return self.extend_from_window_help::<16>(window, range);
+        }
+
         #[cfg(target_arch = "wasm32")]
         if crate::cpu_features::is_enabled_simd128() {
             return self.extend_from_window_help::<16>(window, range);
@@ -241,6 +246,11 @@ impl<'a> Writer<'a> {
 
         #[cfg(target_arch = "aarch64")]
         if crate::cpu_features::is_enabled_neon() {
+            return self.copy_match_help::<16>(offset_from_end, length);
+        }
+
+        #[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+        if crate::cpu_features::is_enabled_lsx() {
             return self.copy_match_help::<16>(offset_from_end, length);
         }
 
@@ -484,6 +494,11 @@ mod test {
 
         #[cfg(target_arch = "aarch64")]
         if crate::cpu_features::is_enabled_neon() {
+            helper!(Writer::copy_match_help::<16>);
+        }
+
+        #[cfg(all(target_arch = "loongarch64", feature = "lsx"))]
+        if crate::cpu_features::is_enabled_lsx() {
             helper!(Writer::copy_match_help::<16>);
         }
 


### PR DESCRIPTION
Some pretty nice gains and AFAICT the last remaining place where we are missing LSX optimizations:

```
Benchmark 1 (107 runs): target/release/examples/uncompress-baseline rs silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          46.6ms ± 1.30ms    44.9ms … 50.3ms          4 ( 4%)        0%
  peak_rss           35.2MB ± 13.1MB    22.0MB … 56.3MB          0 ( 0%)        0%
  cpu_cycles         91.9M  ± 1.58M     89.3M  … 96.8M           2 ( 2%)        0%
  instructions        264M  ±    0       264M  …  264M           0 ( 0%)        0%
  cache_references   63.4M  ± 21.3K     63.2M  … 63.4M           1 ( 1%)        0%
  cache_misses       1.22M  ±  328K      982K  … 2.23M          11 (10%)        0%
Benchmark 2 (113 runs): target/release/examples/blogpost-uncompress rs silesia-small.tar.gz
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          44.2ms ± 1.48ms    42.4ms … 47.5ms          0 ( 0%)        ⚡-  5.2% ±  0.8%
  peak_rss           36.0MB ± 13.9MB    22.8MB … 56.2MB          0 ( 0%)          +  2.2% ± 10.2%
  cpu_cycles         86.4M  ± 1.72M     83.9M  … 90.6M           0 ( 0%)        ⚡-  6.0% ±  0.5%
  instructions        255M  ±    0       255M  …  255M           0 ( 0%)        ⚡-  3.1% ±  0.0%
  cache_references   62.1M  ± 17.5K     62.0M  … 62.1M           4 ( 4%)        ⚡-  2.0% ±  0.0%
  cache_misses       1.10M  ±  206K      963K  … 1.88M           9 ( 8%)        ⚡-  9.7% ±  5.9%
```