### PR TITLE
run with address sanitizer in CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -112,6 +112,10 @@ jobs:
           - target: "aarch64-pc-windows-msvc"
             os: windows-11-arm
             codecov: false
+
+    env:
+      RUSTFLAGS: ${{ matrix.rust == 'nightly' && matrix.target == 'x86_64-unknown-linux-gnu' && '-Zsanitizer=address' || '' }}
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/test-libz-rs-sys/src/inflate.rs
+++ b/test-libz-rs-sys/src/inflate.rs
@@ -2047,6 +2047,8 @@ fn test_inflate_flush_block() {
                 break;
             }
         }
+
+        unsafe { libz_sys::inflateEnd(stream) };
     }
 
     // Log the stream positions and data_type output from libz_rs and compare
@@ -2088,6 +2090,8 @@ fn test_inflate_flush_block() {
                 break;
             }
         }
+
+        unsafe { inflateEnd(stream) };
     }
 }
 


### PR DESCRIPTION
Because why not, and we don't run Miri on all tests.