### PR TITLE
add Deflate from config constructor

### DIFF
--- a/zlib-rs/src/stable.rs
+++ b/zlib-rs/src/stable.rs
@@ -305,20 +305,16 @@ impl Deflate {
             ..DeflateConfig::default()
         };
 
-        Self {
-            inner: crate::deflate::DeflateStream::new(config),
-            total_in: 0,
-            total_out: 0,
-        }
+        Self::new_with_config(config)
     }
 
-    /// Create a new instance from the provided `DeflateConfig`.
+    /// Create a new instance with the provided [`DeflateConfig`].
     ///
-    /// In most cases it is recommended to use the standard `Deflate::new` constructor unless
+    /// In most cases it is recommended to use the standard [`Deflate::new`] constructor unless
     /// tweaking `mem_level` or `strategy` is desired.
     ///
     /// This allocates, so should be done with care.
-    pub fn new_from_config(config: DeflateConfig) -> Self {
+    pub fn new_with_config(config: DeflateConfig) -> Self {
         Self {
             inner: crate::deflate::DeflateStream::new(config),
             total_in: 0,

--- a/zlib-rs/src/stable.rs
+++ b/zlib-rs/src/stable.rs
@@ -312,6 +312,20 @@ impl Deflate {
         }
     }
 
+    /// Create a new instance from the provided `DeflateConfig`.
+    ///
+    /// In most cases it is recommended to use the standard `Deflate::new` constructor unless
+    /// tweaking `mem_level` or `strategy` is desired.
+    ///
+    /// This allocates, so should be done with care.
+    pub fn new_from_config(config: DeflateConfig) -> Self {
+        Self {
+            inner: crate::deflate::DeflateStream::new(config),
+            total_in: 0,
+            total_out: 0,
+        }
+    }
+
     /// Prepare the instance for a new stream.
     pub fn reset(&mut self) {
         self.total_in = 0;


### PR DESCRIPTION
Hello! This diff exposes a new constructor on the `Deflate` struct allowing users to create an instance directly with a set `DeflateConfig`.

I found myself needing this, as I'd like to use `Deflate` with a specific `mem_level` set, which I'm unable to do with the current API.